### PR TITLE
Introduce initial implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules/

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,1 @@
+/test/collateral/

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,6 @@
+{
+  "esversion": 6,
+  "node": true,
+  "undef": true,
+  "unused": true
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+---
+language: node_js
+node_js:
+  - 6
+  - 8

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+# Contribution Guidelines
+
+Thank you for your interest in `test262-stream`!
+
+## Development environment
+
+This project relies on [Node.js](https://nodejs.org) version 6 or higher. Once
+installed, run the following command in a terminal located at the root of this
+project:
+
+    npm install
+
+This will retrieve the Node.js packages necessary to run the project and its
+tests.
+
+## Running the tests
+
+Execute the following command in a terminal located at the root of this
+project:
+
+    npm test
+
+Please ensure that all tests pass before submitting a patch.
+
+The tests reference static files in the `test/` directory to determine expected
+behavior. Contributors who are changing this module's behavior will likely need
+to update these expectations. To ease maintenance, the static files can be
+automatically updated by setting the environment variable named `RECORD` prior
+to running the tests. On Unix-like systems, this can be achieved by running the
+tests with the following command:
+
+    RECORD=true npm test
+
+When executed under these conditions, the tests will always pass and the
+expectation files will be modified to describe the current behavior. The
+modified versions should be verified for correctness and checked in to the
+project.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,27 @@
+Copyright (c) 2017, Bocoup LLC
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of [project] nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,61 @@
 # Test262-Stream
 
-Coming soon!
+A [Node.js](https://nodejs.org) API for traversing [the Test262 test
+suite](https://github.com/tc39/test262).
+
+## Usage
+
+```js
+var TestStream = require('test262-stream');
+var stream = new TestStream('/path/to/test262', {
+    // Directory from which to load "includes" files (defaults to the
+    // appropriate subdirectory of the provided `test262Dir`
+    // Optional. Defaults to './harness'
+    includesDir: '/path/to/includes/dir',
+
+    // File system paths refining the set of tests that should be produced;
+    // only tests whose source file matches one of these values (in the case of
+    // file paths) or is contained by one of these paths (in the case of
+    // directory paths) will be created; all paths are interpreted relative to
+    // the root of the provided `test262Dir`
+    // Optional. Defaults to ['test']
+    paths: ['test/built-ins/eval', 'test/language/statements/empty/S12.3_A1.js']
+  });
+
+stream.on('data', function(test) {
+    // the path to the file from which the test was derived, relative to the
+    // provided Test262 directory
+    console.log(test.file);
+
+    // the complete source text for the test; this contains any "includes"
+    // files specified in the frontmatter, "prelude" content if specified (see
+    // below), and any "scenario" transformations
+    console.log(test.contents);
+
+    // an object representation of the metadata declared in the test's
+    // "frontmatter" section
+    console.log(test.attrs);
+
+    // the licensing information included within the test (if any)
+    console.log(test.copyright);
+
+    // name describing how the source file was interpreted to create the test
+    console.log(test.scenario);
+
+    // numeric offset within the `contents` string at which one or more
+    // statements may be inserted without necessarily invalidating the test
+    console.log(test.insertionIndex);
+  });
+
+stream.on('end', function() {
+    console.log('No further tests.');
+  });
+
+stream.on('error', function(err) {
+    console.error('Something went wrong:', err);
+  });
+```
+
+## License
+
+Copyright 2017, Bocoup LLC under the 3-Clause BSD License (see `LICENSE.txt`)

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -1,0 +1,43 @@
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const compile = require('test262-compiler');
+
+const createScenarios = require('./create-scenarios');
+
+const endFrontmatterPattern = /---\*\/\r?\n/g;
+const test262StreamMarker = '/* Inserted by Test262Stream */';
+
+module.exports = function (filePath, options, done) {
+  fs.readFile(filePath, 'utf-8', (err, contents) => {
+    if (err) {
+      done(err);
+      return;
+    }
+
+    // The "compilation" process removes the tests' frontmatter, so a temporary
+    // marker must be introduced so the insertion index can be identified
+    // following compilation.
+    contents = contents
+      .replace(endFrontmatterPattern, '$&' + test262StreamMarker);
+
+    const descriptor = { file: filePath, contents };
+    const tests = createScenarios(compile(descriptor, options));
+
+    tests.forEach((test) => {
+      test.insertionIndex = test.attrs.flags.raw ?
+        -1 : test.contents.indexOf(test262StreamMarker);
+      test.contents = test.contents.replace(test262StreamMarker, '');
+
+      test.file = path.relative(options.test262Dir, test.file);
+
+      // The following properties are provided by the `test262-parser` module,
+      // they are inconsistent and possibly confusing.
+      delete test.isATest;
+      delete test.async;
+      delete test.strictMode;
+    });
+
+    done(null, tests);
+  });
+};

--- a/lib/create-scenarios.js
+++ b/lib/create-scenarios.js
@@ -1,0 +1,24 @@
+'use strict';
+
+module.exports = function scenariosForTest(test) {
+  // The `test262-compiler` project inserts a global "use strict" directive for
+  // tests marked with the `onlyStrict` flag. While this obviates the need for
+  // additional transformations to the source, the `scenario` metadata must
+  // still be set accordingly.
+  test.scenario = test.attrs.flags.onlyStrict ? 'strict mode' : 'default';
+
+  if (!test.attrs.flags.onlyStrict &&
+      !test.attrs.flags.noStrict &&
+      !test.attrs.flags.raw) {
+
+    const copy = Object.assign({}, test);
+    copy.attrs = Object.assign({}, test.attrs);
+    copy.attrs.description += ' (Strict Mode)';
+    copy.contents = `"use strict";\n${copy.contents}`;
+    copy.scenario = 'strict mode';
+    // test both modes
+    return [test, copy];
+  } else {
+    return [test];
+  }
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,128 @@
+'use strict';
+const path = require('path');
+const Readable = require('stream').Readable;
+
+const klaw = require('klaw');
+
+const compile = require('./compile');
+
+const paths = Symbol('paths');
+const compileOpts = Symbol('includesDir');
+const fileStream = Symbol('fileStream');
+const onFile = Symbol('onFile');
+const pendingOps = Symbol('pendingOps');
+const fileStreamDone = Symbol('fileStreamDone');
+
+const fixturePattern = /_FIXTURE\.[jJ][sS]$/;
+
+/**
+ * A Node.js readable stream that emits an object value for every test in a
+ * given filesystem directory. This object has the following properties:
+ *
+ * - file {string} - the path to the file from which the test was derived,
+ *                   relative to the provided Test262 directory
+ * - contents {string} - the complete source text for the test; this contains
+ *                       any "includes" files specified in the frontmatter,
+ *                       "prelude" content if specified (see below), and any
+ *                       "scenario" transformations
+ * - attrs {object} - an object representation of the metadata declared in the
+ *                    test's YAML-formatted "frontmatter" section
+ * - copyright {string} - the licensing information included within the test
+ *                        (if any)
+ * - scenario {string} - name describing how the source file was interpreted to
+ *                       create the test
+ * - insertionIndex {number} - numeric offset within the `contents` string at
+ *                             which one or more statements may be inserted
+ *                             without necessarily invalidating the test
+ *
+ * @param {string} test262Dir - filesystem path to a directory containing
+ *                              Test262
+ * @param {object} [options]
+ * @param {string} [options.includesDir] - directory from which to load
+ *                                         "includes" files (defaults to the
+ *                                         appropriate subdirectory of the
+ *                                         provided `test262Dir`
+ * @param {Array<string>} [options.paths] - file system paths refining the set
+ *                                          of tests that should be produced;
+ *                                          only tests whose source file
+ *                                          matches one of these values (in the
+ *                                          case of file paths) or is contained
+ *                                          by one of these paths (in the case
+ *                                          of directory paths) will be
+ *                                          created; all paths are interpreted
+ *                                          relative to the root of the
+ *                                          provided `test262Dir`
+ * @param {string} [options.prelude] - string contents to inject into each
+ *                                     test that does not carry the `raw`
+ *                                     metadata flag; defaults to the empty
+ *                                     string (e.g. no injection)
+ *
+ * @returns {object} readable stream
+ */
+module.exports = class TestStream extends Readable {
+  constructor(test262Dir, options) {
+    options = Object.assign({}, options);
+    options.objectMode = true;
+    super(options);
+    this[test262Dir] = test262Dir;
+    this[paths] = (options.paths || ['test'])
+      .map(relativePath => path.join(test262Dir, relativePath));
+    this[compileOpts] = {
+      test262Dir,
+      includesDir: options.includesDir
+    };
+    this[fileStream] = null;
+    this[pendingOps] = 0;
+    this[fileStreamDone] = false;
+  }
+
+  _read() {
+    if (this[fileStream]) {
+      return;
+    }
+
+    (function traverse() {
+      this[fileStream] = klaw(this[paths].shift());
+
+      this[fileStream].on('data', (item) => this[onFile](item));
+      this[fileStream].on('error', (error) => this.emit('error', error));
+
+      this[fileStream].on('end', () => {
+        if (this[paths].length) {
+          traverse.call(this);
+        } else {
+          this[fileStreamDone] = true;
+        }
+      });
+    }.call(this));
+  }
+
+  [onFile](item) {
+    if (!item.stats.isFile()) {
+      return;
+    }
+    if (path.basename(item.path)[0] === '.') {
+      return;
+    }
+    if (fixturePattern.test(item.path)) {
+      return;
+    }
+
+    this[pendingOps] += 1;
+
+    compile(item.path, this[compileOpts], (err, tests) => {
+      this[pendingOps] -= 1;
+
+      if (err) {
+        this.emit('error', err);
+        return;
+      }
+
+      tests.forEach((test) => this.push(test));
+
+      if (this[pendingOps] === 0 && this[fileStreamDone]) {
+        this.push(null);
+      }
+    });
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,863 @@
+{
+  "name": "test262-stream",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "argparse": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+    },
+    "camelcase": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+      "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+    },
+    "cli": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
+      "integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=",
+      "dev": true,
+      "requires": {
+        "exit": "0.1.2",
+        "glob": "7.1.2"
+      }
+    },
+    "cliui": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "requires": {
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wrap-ansi": "2.1.0"
+      }
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "console-browserify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+      "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+      "dev": true,
+      "requires": {
+        "date-now": "0.1.4"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "date-now": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+      "dev": true
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "dev": true,
+      "requires": {
+        "foreach": "2.0.5",
+        "object-keys": "1.0.11"
+      }
+    },
+    "defined": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+      "dev": true
+    },
+    "dom-serializer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.1.3",
+        "entities": "1.1.1"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+          "dev": true
+        },
+        "entities": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+          "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+          "dev": true
+        }
+      }
+    },
+    "domelementtype": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+      "dev": true
+    },
+    "domhandler": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+      "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.3.0"
+      }
+    },
+    "domutils": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+      "dev": true,
+      "requires": {
+        "dom-serializer": "0.1.0",
+        "domelementtype": "1.3.0"
+      }
+    },
+    "entities": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+      "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
+      "dev": true
+    },
+    "error-ex": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "requires": {
+        "is-arrayish": "0.2.1"
+      }
+    },
+    "es-abstract": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.9.0.tgz",
+      "integrity": "sha512-kk3IJoKo7A3pWJc0OV8yZ/VEX2oSUytfekrJiqoxBlKJMFAJVJVpGdHClCCTdv+Fn2zHfpDHHIelMFhZVfef3Q==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.1",
+        "has": "1.0.1",
+        "is-callable": "1.1.3",
+        "is-regex": "1.0.4"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+      "dev": true,
+      "requires": {
+        "is-callable": "1.1.3",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
+      }
+    },
+    "esprima": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+    },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
+    },
+    "find-up": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "requires": {
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "for-each": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
+      "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
+      "dev": true,
+      "requires": {
+        "is-function": "1.0.1"
+      }
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "get-caller-file": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+    },
+    "has": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "dev": true,
+      "requires": {
+        "function-bind": "1.1.1"
+      }
+    },
+    "hosted-git-info": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
+    },
+    "htmlparser2": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+      "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.3.0",
+        "domhandler": "2.3.0",
+        "domutils": "1.5.1",
+        "entities": "1.0.0",
+        "readable-stream": "1.1.14"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+    },
+    "is-builtin-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "requires": {
+        "builtin-modules": "1.1.1"
+      }
+    },
+    "is-callable": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+      "dev": true
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
+    },
+    "is-function": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
+      "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU=",
+      "dev": true
+    },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "1.0.1"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
+      "dev": true
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+      "requires": {
+        "argparse": "1.0.9",
+        "esprima": "4.0.0"
+      }
+    },
+    "jshint": {
+      "version": "2.9.5",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.5.tgz",
+      "integrity": "sha1-HnJSkVzmgbQIJ+4UJIxG006apiw=",
+      "dev": true,
+      "requires": {
+        "cli": "1.0.1",
+        "console-browserify": "1.1.0",
+        "exit": "0.1.2",
+        "htmlparser2": "3.8.3",
+        "lodash": "3.7.0",
+        "minimatch": "3.0.4",
+        "shelljs": "0.3.0",
+        "strip-json-comments": "1.0.4"
+      }
+    },
+    "klaw": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-2.1.0.tgz",
+      "integrity": "sha1-aUomkBn0Mh2SM/sbmr2uIeOCWfs=",
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
+    },
+    "lcid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "requires": {
+        "invert-kv": "1.0.0"
+      }
+    },
+    "load-json-file": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0"
+      }
+    },
+    "lodash": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz",
+      "integrity": "sha1-Nni9irmVBXwHreg27S7wh9qBHUU=",
+      "dev": true
+    },
+    "lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "requires": {
+        "hosted-git-info": "2.5.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.4.1",
+        "validate-npm-package-license": "3.0.1"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    },
+    "object-inspect": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.3.0.tgz",
+      "integrity": "sha512-OHHnLgLNXpM++GnJRyyhbr2bwl3pPVm4YvaraHrRvDt/N3r+s/gDVHciA7EJBTkijKXj61ssgSAikq1fb0IBRg==",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "os-locale": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "requires": {
+        "lcid": "1.0.0"
+      }
+    },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "requires": {
+        "error-ex": "1.3.1"
+      }
+    },
+    "path-exists": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "requires": {
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "dev": true
+    },
+    "path-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "requires": {
+        "pinkie": "2.0.4"
+      }
+    },
+    "read-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "requires": {
+        "load-json-file": "1.1.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "1.1.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "requires": {
+        "find-up": "1.1.2",
+        "read-pkg": "1.1.0"
+      }
+    },
+    "readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+      "dev": true,
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "0.0.1",
+        "string_decoder": "0.10.31"
+      }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+    },
+    "require-main-filename": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+    },
+    "resolve": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
+      "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
+      }
+    },
+    "resumer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+      "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
+      "dev": true,
+      "requires": {
+        "through": "2.3.8"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2"
+      }
+    },
+    "semver": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
+    "shelljs": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+      "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
+      "dev": true
+    },
+    "spdx-correct": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+      "requires": {
+        "spdx-license-ids": "1.2.2"
+      }
+    },
+    "spdx-expression-parse": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
+    },
+    "spdx-license-ids": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
+      }
+    },
+    "string.prototype.trim": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
+      "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.9.0",
+        "function-bind": "1.1.1"
+      }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "strip-bom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "requires": {
+        "is-utf8": "0.2.1"
+      }
+    },
+    "strip-json-comments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+      "dev": true
+    },
+    "tape": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-4.8.0.tgz",
+      "integrity": "sha512-TWILfEnvO7I8mFe35d98F6T5fbLaEtbFTG/lxWvid8qDfFTxt19EBijWmB4j3+Hoh5TfHE2faWs73ua+EphuBA==",
+      "dev": true,
+      "requires": {
+        "deep-equal": "1.0.1",
+        "defined": "1.0.0",
+        "for-each": "0.3.2",
+        "function-bind": "1.1.1",
+        "glob": "7.1.2",
+        "has": "1.0.1",
+        "inherits": "2.0.3",
+        "minimist": "1.2.0",
+        "object-inspect": "1.3.0",
+        "resolve": "1.4.0",
+        "resumer": "0.0.0",
+        "string.prototype.trim": "1.1.2",
+        "through": "2.3.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "test262-compiler": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/test262-compiler/-/test262-compiler-3.0.0.tgz",
+      "integrity": "sha1-+4EcH9XWLPhyttWzOquW/09O1yM=",
+      "requires": {
+        "test262-parser": "2.0.7",
+        "yargs": "4.8.1"
+      }
+    },
+    "test262-parser": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/test262-parser/-/test262-parser-2.0.7.tgz",
+      "integrity": "sha1-cztGv3dZ50fq40tbFNajyNIIKt0=",
+      "requires": {
+        "js-yaml": "3.10.0",
+        "through": "2.3.8"
+      }
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+      "requires": {
+        "spdx-correct": "1.0.2",
+        "spdx-expression-parse": "1.0.4"
+      }
+    },
+    "which-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+    },
+    "window-size": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+      "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
+    },
+    "wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "requires": {
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "y18n": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+    },
+    "yargs": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
+      "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
+      "requires": {
+        "cliui": "3.2.0",
+        "decamelize": "1.2.0",
+        "get-caller-file": "1.0.2",
+        "lodash.assign": "4.2.0",
+        "os-locale": "1.4.0",
+        "read-pkg-up": "1.0.1",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "1.0.2",
+        "which-module": "1.0.0",
+        "window-size": "0.2.0",
+        "y18n": "3.2.1",
+        "yargs-parser": "2.4.1"
+      }
+    },
+    "yargs-parser": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
+      "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
+      "requires": {
+        "camelcase": "3.0.0",
+        "lodash.assign": "4.2.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "test262-stream",
+  "version": "1.0.0",
+  "description": "A Node.js API for traversing the Test262 test suite",
+  "main": "lib/index.js",
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "lint": "jshint lib test",
+    "test": "npm run lint && npm run test-unit",
+    "test-unit": "tape test/test.js"
+  },
+  "author": "",
+  "license": "BSD-3-Clause",
+  "devDependencies": {
+    "jshint": "^2.9.5",
+    "mkdirp": "^0.5.1",
+    "rimraf": "^2.6.2",
+    "tape": "^4.8.0"
+  },
+  "dependencies": {
+    "klaw": "^2.1.0",
+    "test262-compiler": "^3.0.0"
+  }
+}

--- a/test/collateral/invalid-missing-harness/fake-test262/test/a-test-file.js
+++ b/test/collateral/invalid-missing-harness/fake-test262/test/a-test-file.js
@@ -1,0 +1,16 @@
+/*---
+description: Should test in both modes
+negative:
+  phase: runtime
+  type: ReferenceError
+expected:
+  pass: true
+---*/
+var strict;
+try { x = 1; strict = false;} catch(e) { strict = true }
+
+if(strict) {
+    y = 1;
+} else {
+    throw new ReferenceError();
+}

--- a/test/collateral/valid-default/expected-content/test/asyncNegative_default.js
+++ b/test/collateral/valid-default/expected-content/test/asyncNegative_default.js
@@ -1,0 +1,57 @@
+function Test262Error(message) {
+    if (message) this.message = message;
+}
+
+Test262Error.prototype.name = "Test262Error";
+
+Test262Error.prototype.toString = function () {
+    return "Test262Error: " + this.message;
+};
+
+function $ERROR(err) {
+  if(typeof err === "object" && err !== null && "name" in err) {
+      throw err;
+  } else {
+    throw new Test262Error(err);
+  }
+}
+
+function $DONE(err) {
+  if (err) {
+    if(typeof err === "object" && err !== null && "name" in err) {
+      print('test262/error ' + err.name + ': ' + err.message);
+    } else {
+      print('test262/error Test262Error: ' + err);
+    }
+  }
+  print('test262/done');
+  $262.destroy();
+}
+
+function $LOG(str) {
+  print(str);
+}
+
+
+// This is assert.js
+
+'It has some contents';
+
+/* that
+ *
+ * should
+
+ * not
+ */
+
+`be ${ "modified" }`;
+
+var including, trailing;
+whitespace: ;                    
+
+void "end of assert.js";
+
+
+setTimeout(function() {
+  $DONE(new RangeError());
+}, 1000);

--- a/test/collateral/valid-default/expected-content/test/asyncNegative_strict_mode.js
+++ b/test/collateral/valid-default/expected-content/test/asyncNegative_strict_mode.js
@@ -1,0 +1,58 @@
+"use strict";
+function Test262Error(message) {
+    if (message) this.message = message;
+}
+
+Test262Error.prototype.name = "Test262Error";
+
+Test262Error.prototype.toString = function () {
+    return "Test262Error: " + this.message;
+};
+
+function $ERROR(err) {
+  if(typeof err === "object" && err !== null && "name" in err) {
+      throw err;
+  } else {
+    throw new Test262Error(err);
+  }
+}
+
+function $DONE(err) {
+  if (err) {
+    if(typeof err === "object" && err !== null && "name" in err) {
+      print('test262/error ' + err.name + ': ' + err.message);
+    } else {
+      print('test262/error Test262Error: ' + err);
+    }
+  }
+  print('test262/done');
+  $262.destroy();
+}
+
+function $LOG(str) {
+  print(str);
+}
+
+
+// This is assert.js
+
+'It has some contents';
+
+/* that
+ *
+ * should
+
+ * not
+ */
+
+`be ${ "modified" }`;
+
+var including, trailing;
+whitespace: ;                    
+
+void "end of assert.js";
+
+
+setTimeout(function() {
+  $DONE(new RangeError());
+}, 1000);

--- a/test/collateral/valid-default/expected-content/test/async_default.js
+++ b/test/collateral/valid-default/expected-content/test/async_default.js
@@ -1,0 +1,59 @@
+function Test262Error(message) {
+    if (message) this.message = message;
+}
+
+Test262Error.prototype.name = "Test262Error";
+
+Test262Error.prototype.toString = function () {
+    return "Test262Error: " + this.message;
+};
+
+function $ERROR(err) {
+  if(typeof err === "object" && err !== null && "name" in err) {
+      throw err;
+  } else {
+    throw new Test262Error(err);
+  }
+}
+
+function $DONE(err) {
+  if (err) {
+    if(typeof err === "object" && err !== null && "name" in err) {
+      print('test262/error ' + err.name + ': ' + err.message);
+    } else {
+      print('test262/error Test262Error: ' + err);
+    }
+  }
+  print('test262/done');
+  $262.destroy();
+}
+
+function $LOG(str) {
+  print(str);
+}
+
+
+// This is assert.js
+
+'It has some contents';
+
+/* that
+ *
+ * should
+
+ * not
+ */
+
+`be ${ "modified" }`;
+
+var including, trailing;
+whitespace: ;                    
+
+void "end of assert.js";
+
+
+var p = new Promise(function(resolve) {
+  resolve();
+});
+
+p.then($DONE, $DONE);

--- a/test/collateral/valid-default/expected-content/test/async_strict_mode.js
+++ b/test/collateral/valid-default/expected-content/test/async_strict_mode.js
@@ -1,0 +1,60 @@
+"use strict";
+function Test262Error(message) {
+    if (message) this.message = message;
+}
+
+Test262Error.prototype.name = "Test262Error";
+
+Test262Error.prototype.toString = function () {
+    return "Test262Error: " + this.message;
+};
+
+function $ERROR(err) {
+  if(typeof err === "object" && err !== null && "name" in err) {
+      throw err;
+  } else {
+    throw new Test262Error(err);
+  }
+}
+
+function $DONE(err) {
+  if (err) {
+    if(typeof err === "object" && err !== null && "name" in err) {
+      print('test262/error ' + err.name + ': ' + err.message);
+    } else {
+      print('test262/error Test262Error: ' + err);
+    }
+  }
+  print('test262/done');
+  $262.destroy();
+}
+
+function $LOG(str) {
+  print(str);
+}
+
+
+// This is assert.js
+
+'It has some contents';
+
+/* that
+ *
+ * should
+
+ * not
+ */
+
+`be ${ "modified" }`;
+
+var including, trailing;
+whitespace: ;                    
+
+void "end of assert.js";
+
+
+var p = new Promise(function(resolve) {
+  resolve();
+});
+
+p.then($DONE, $DONE);

--- a/test/collateral/valid-default/expected-content/test/bothStrict_default.js
+++ b/test/collateral/valid-default/expected-content/test/bothStrict_default.js
@@ -1,0 +1,63 @@
+function Test262Error(message) {
+    if (message) this.message = message;
+}
+
+Test262Error.prototype.name = "Test262Error";
+
+Test262Error.prototype.toString = function () {
+    return "Test262Error: " + this.message;
+};
+
+function $ERROR(err) {
+  if(typeof err === "object" && err !== null && "name" in err) {
+      throw err;
+  } else {
+    throw new Test262Error(err);
+  }
+}
+
+function $DONE(err) {
+  if (err) {
+    if(typeof err === "object" && err !== null && "name" in err) {
+      print('test262/error ' + err.name + ': ' + err.message);
+    } else {
+      print('test262/error Test262Error: ' + err);
+    }
+  }
+  print('test262/done');
+  $262.destroy();
+}
+
+function $LOG(str) {
+  print(str);
+}
+
+
+// This is assert.js
+
+'It has some contents';
+
+/* that
+ *
+ * should
+
+ * not
+ */
+
+`be ${ "modified" }`;
+
+var including, trailing;
+whitespace: ;                    
+
+void "end of assert.js";
+
+var strict;
+try { x = 1; strict = false;} catch(e) { strict = true }
+
+if(strict) {
+    y = 1;
+} else {
+    throw new ReferenceError();
+}
+
+;$DONE();

--- a/test/collateral/valid-default/expected-content/test/bothStrict_strict_mode.js
+++ b/test/collateral/valid-default/expected-content/test/bothStrict_strict_mode.js
@@ -1,0 +1,64 @@
+"use strict";
+function Test262Error(message) {
+    if (message) this.message = message;
+}
+
+Test262Error.prototype.name = "Test262Error";
+
+Test262Error.prototype.toString = function () {
+    return "Test262Error: " + this.message;
+};
+
+function $ERROR(err) {
+  if(typeof err === "object" && err !== null && "name" in err) {
+      throw err;
+  } else {
+    throw new Test262Error(err);
+  }
+}
+
+function $DONE(err) {
+  if (err) {
+    if(typeof err === "object" && err !== null && "name" in err) {
+      print('test262/error ' + err.name + ': ' + err.message);
+    } else {
+      print('test262/error Test262Error: ' + err);
+    }
+  }
+  print('test262/done');
+  $262.destroy();
+}
+
+function $LOG(str) {
+  print(str);
+}
+
+
+// This is assert.js
+
+'It has some contents';
+
+/* that
+ *
+ * should
+
+ * not
+ */
+
+`be ${ "modified" }`;
+
+var including, trailing;
+whitespace: ;                    
+
+void "end of assert.js";
+
+var strict;
+try { x = 1; strict = false;} catch(e) { strict = true }
+
+if(strict) {
+    y = 1;
+} else {
+    throw new ReferenceError();
+}
+
+;$DONE();

--- a/test/collateral/valid-default/expected-content/test/error_default.js
+++ b/test/collateral/valid-default/expected-content/test/error_default.js
@@ -1,0 +1,57 @@
+function Test262Error(message) {
+    if (message) this.message = message;
+}
+
+Test262Error.prototype.name = "Test262Error";
+
+Test262Error.prototype.toString = function () {
+    return "Test262Error: " + this.message;
+};
+
+function $ERROR(err) {
+  if(typeof err === "object" && err !== null && "name" in err) {
+      throw err;
+  } else {
+    throw new Test262Error(err);
+  }
+}
+
+function $DONE(err) {
+  if (err) {
+    if(typeof err === "object" && err !== null && "name" in err) {
+      print('test262/error ' + err.name + ': ' + err.message);
+    } else {
+      print('test262/error Test262Error: ' + err);
+    }
+  }
+  print('test262/done');
+  $262.destroy();
+}
+
+function $LOG(str) {
+  print(str);
+}
+
+
+// This is assert.js
+
+'It has some contents';
+
+/* that
+ *
+ * should
+
+ * not
+ */
+
+`be ${ "modified" }`;
+
+var including, trailing;
+whitespace: ;                    
+
+void "end of assert.js";
+
+
+$ERROR('failure message');
+
+;$DONE();

--- a/test/collateral/valid-default/expected-content/test/error_strict_mode.js
+++ b/test/collateral/valid-default/expected-content/test/error_strict_mode.js
@@ -1,0 +1,58 @@
+"use strict";
+function Test262Error(message) {
+    if (message) this.message = message;
+}
+
+Test262Error.prototype.name = "Test262Error";
+
+Test262Error.prototype.toString = function () {
+    return "Test262Error: " + this.message;
+};
+
+function $ERROR(err) {
+  if(typeof err === "object" && err !== null && "name" in err) {
+      throw err;
+  } else {
+    throw new Test262Error(err);
+  }
+}
+
+function $DONE(err) {
+  if (err) {
+    if(typeof err === "object" && err !== null && "name" in err) {
+      print('test262/error ' + err.name + ': ' + err.message);
+    } else {
+      print('test262/error Test262Error: ' + err);
+    }
+  }
+  print('test262/done');
+  $262.destroy();
+}
+
+function $LOG(str) {
+  print(str);
+}
+
+
+// This is assert.js
+
+'It has some contents';
+
+/* that
+ *
+ * should
+
+ * not
+ */
+
+`be ${ "modified" }`;
+
+var including, trailing;
+whitespace: ;                    
+
+void "end of assert.js";
+
+
+$ERROR('failure message');
+
+;$DONE();

--- a/test/collateral/valid-default/expected-content/test/module_default.js
+++ b/test/collateral/valid-default/expected-content/test/module_default.js
@@ -1,0 +1,57 @@
+function Test262Error(message) {
+    if (message) this.message = message;
+}
+
+Test262Error.prototype.name = "Test262Error";
+
+Test262Error.prototype.toString = function () {
+    return "Test262Error: " + this.message;
+};
+
+function $ERROR(err) {
+  if(typeof err === "object" && err !== null && "name" in err) {
+      throw err;
+  } else {
+    throw new Test262Error(err);
+  }
+}
+
+function $DONE(err) {
+  if (err) {
+    if(typeof err === "object" && err !== null && "name" in err) {
+      print('test262/error ' + err.name + ': ' + err.message);
+    } else {
+      print('test262/error Test262Error: ' + err);
+    }
+  }
+  print('test262/done');
+  $262.destroy();
+}
+
+function $LOG(str) {
+  print(str);
+}
+
+
+// This is assert.js
+
+'It has some contents';
+
+/* that
+ *
+ * should
+
+ * not
+ */
+
+`be ${ "modified" }`;
+
+var including, trailing;
+whitespace: ;                    
+
+void "end of assert.js";
+
+
+import fixture from './module_FIXTURE.js';
+
+;$DONE();

--- a/test/collateral/valid-default/expected-content/test/module_strict_mode.js
+++ b/test/collateral/valid-default/expected-content/test/module_strict_mode.js
@@ -1,0 +1,58 @@
+"use strict";
+function Test262Error(message) {
+    if (message) this.message = message;
+}
+
+Test262Error.prototype.name = "Test262Error";
+
+Test262Error.prototype.toString = function () {
+    return "Test262Error: " + this.message;
+};
+
+function $ERROR(err) {
+  if(typeof err === "object" && err !== null && "name" in err) {
+      throw err;
+  } else {
+    throw new Test262Error(err);
+  }
+}
+
+function $DONE(err) {
+  if (err) {
+    if(typeof err === "object" && err !== null && "name" in err) {
+      print('test262/error ' + err.name + ': ' + err.message);
+    } else {
+      print('test262/error Test262Error: ' + err);
+    }
+  }
+  print('test262/done');
+  $262.destroy();
+}
+
+function $LOG(str) {
+  print(str);
+}
+
+
+// This is assert.js
+
+'It has some contents';
+
+/* that
+ *
+ * should
+
+ * not
+ */
+
+`be ${ "modified" }`;
+
+var including, trailing;
+whitespace: ;                    
+
+void "end of assert.js";
+
+
+import fixture from './module_FIXTURE.js';
+
+;$DONE();

--- a/test/collateral/valid-default/expected-content/test/negative-empty_default.js
+++ b/test/collateral/valid-default/expected-content/test/negative-empty_default.js
@@ -1,0 +1,55 @@
+function Test262Error(message) {
+    if (message) this.message = message;
+}
+
+Test262Error.prototype.name = "Test262Error";
+
+Test262Error.prototype.toString = function () {
+    return "Test262Error: " + this.message;
+};
+
+function $ERROR(err) {
+  if(typeof err === "object" && err !== null && "name" in err) {
+      throw err;
+  } else {
+    throw new Test262Error(err);
+  }
+}
+
+function $DONE(err) {
+  if (err) {
+    if(typeof err === "object" && err !== null && "name" in err) {
+      print('test262/error ' + err.name + ': ' + err.message);
+    } else {
+      print('test262/error Test262Error: ' + err);
+    }
+  }
+  print('test262/done');
+  $262.destroy();
+}
+
+function $LOG(str) {
+  print(str);
+}
+
+
+// This is assert.js
+
+'It has some contents';
+
+/* that
+ *
+ * should
+
+ * not
+ */
+
+`be ${ "modified" }`;
+
+var including, trailing;
+whitespace: ;                    
+
+void "end of assert.js";
+
+
+;$DONE();

--- a/test/collateral/valid-default/expected-content/test/negative-empty_strict_mode.js
+++ b/test/collateral/valid-default/expected-content/test/negative-empty_strict_mode.js
@@ -1,0 +1,56 @@
+"use strict";
+function Test262Error(message) {
+    if (message) this.message = message;
+}
+
+Test262Error.prototype.name = "Test262Error";
+
+Test262Error.prototype.toString = function () {
+    return "Test262Error: " + this.message;
+};
+
+function $ERROR(err) {
+  if(typeof err === "object" && err !== null && "name" in err) {
+      throw err;
+  } else {
+    throw new Test262Error(err);
+  }
+}
+
+function $DONE(err) {
+  if (err) {
+    if(typeof err === "object" && err !== null && "name" in err) {
+      print('test262/error ' + err.name + ': ' + err.message);
+    } else {
+      print('test262/error Test262Error: ' + err);
+    }
+  }
+  print('test262/done');
+  $262.destroy();
+}
+
+function $LOG(str) {
+  print(str);
+}
+
+
+// This is assert.js
+
+'It has some contents';
+
+/* that
+ *
+ * should
+
+ * not
+ */
+
+`be ${ "modified" }`;
+
+var including, trailing;
+whitespace: ;                    
+
+void "end of assert.js";
+
+
+;$DONE();

--- a/test/collateral/valid-default/expected-content/test/noStrict_default.js
+++ b/test/collateral/valid-default/expected-content/test/noStrict_default.js
@@ -1,0 +1,56 @@
+function Test262Error(message) {
+    if (message) this.message = message;
+}
+
+Test262Error.prototype.name = "Test262Error";
+
+Test262Error.prototype.toString = function () {
+    return "Test262Error: " + this.message;
+};
+
+function $ERROR(err) {
+  if(typeof err === "object" && err !== null && "name" in err) {
+      throw err;
+  } else {
+    throw new Test262Error(err);
+  }
+}
+
+function $DONE(err) {
+  if (err) {
+    if(typeof err === "object" && err !== null && "name" in err) {
+      print('test262/error ' + err.name + ': ' + err.message);
+    } else {
+      print('test262/error Test262Error: ' + err);
+    }
+  }
+  print('test262/done');
+  $262.destroy();
+}
+
+function $LOG(str) {
+  print(str);
+}
+
+
+// This is assert.js
+
+'It has some contents';
+
+/* that
+ *
+ * should
+
+ * not
+ */
+
+`be ${ "modified" }`;
+
+var including, trailing;
+whitespace: ;                    
+
+void "end of assert.js";
+
+x = 5;
+
+;$DONE();

--- a/test/collateral/valid-default/expected-content/test/rawNoStrict_default.js
+++ b/test/collateral/valid-default/expected-content/test/rawNoStrict_default.js
@@ -1,0 +1,11 @@
+
+var seemsStrict;
+try {
+  x = 1;
+} catch (err) {
+  seemsStrict = err.constructor === ReferenceError;
+}
+
+if (seemsStrict) {
+  throw new Error('Script erroneously interpreted in strict mode.');
+}

--- a/test/collateral/valid-default/expected-content/test/rawStrict_default.js
+++ b/test/collateral/valid-default/expected-content/test/rawStrict_default.js
@@ -1,0 +1,12 @@
+
+'use strict';
+var seemsStrict;
+try {
+  x = 1;
+} catch (err) {
+  seemsStrict = err.constructor === ReferenceError;
+}
+
+if (!seemsStrict) {
+  throw new Error('Script erroneously not interpreted in strict mode.');
+}

--- a/test/collateral/valid-default/expected-content/test/strict_strict_mode.js
+++ b/test/collateral/valid-default/expected-content/test/strict_strict_mode.js
@@ -1,0 +1,58 @@
+"use strict";
+function Test262Error(message) {
+    if (message) this.message = message;
+}
+
+Test262Error.prototype.name = "Test262Error";
+
+Test262Error.prototype.toString = function () {
+    return "Test262Error: " + this.message;
+};
+
+function $ERROR(err) {
+  if(typeof err === "object" && err !== null && "name" in err) {
+      throw err;
+  } else {
+    throw new Test262Error(err);
+  }
+}
+
+function $DONE(err) {
+  if (err) {
+    if(typeof err === "object" && err !== null && "name" in err) {
+      print('test262/error ' + err.name + ': ' + err.message);
+    } else {
+      print('test262/error Test262Error: ' + err);
+    }
+  }
+  print('test262/done');
+  $262.destroy();
+}
+
+function $LOG(str) {
+  print(str);
+}
+
+
+// This is assert.js
+
+'It has some contents';
+
+/* that
+ *
+ * should
+
+ * not
+ */
+
+`be ${ "modified" }`;
+
+var including, trailing;
+whitespace: ;                    
+
+void "end of assert.js";
+
+x = 5;
+$ERROR('Not in strict mode');
+
+;$DONE();

--- a/test/collateral/valid-default/expected-metadata/test/asyncNegative_default.json
+++ b/test/collateral/valid-default/expected-metadata/test/asyncNegative_default.json
@@ -1,0 +1,20 @@
+{
+  "file": "test/asyncNegative.js",
+  "contents": "(The value of this property is over-sized, so it is validated independently.)",
+  "attrs": {
+    "description": "Async negative test",
+    "negative": {
+      "phase": "runtime",
+      "type": "RangeError"
+    },
+    "flags": {
+      "async": true
+    },
+    "includes": [
+      "assert.js"
+    ]
+  },
+  "copyright": "",
+  "scenario": "default",
+  "insertionIndex": 890
+}

--- a/test/collateral/valid-default/expected-metadata/test/asyncNegative_strict_mode.json
+++ b/test/collateral/valid-default/expected-metadata/test/asyncNegative_strict_mode.json
@@ -1,0 +1,20 @@
+{
+  "file": "test/asyncNegative.js",
+  "contents": "(The value of this property is over-sized, so it is validated independently.)",
+  "attrs": {
+    "description": "Async negative test (Strict Mode)",
+    "negative": {
+      "phase": "runtime",
+      "type": "RangeError"
+    },
+    "flags": {
+      "async": true
+    },
+    "includes": [
+      "assert.js"
+    ]
+  },
+  "copyright": "",
+  "scenario": "strict mode",
+  "insertionIndex": 904
+}

--- a/test/collateral/valid-default/expected-metadata/test/async_default.json
+++ b/test/collateral/valid-default/expected-metadata/test/async_default.json
@@ -1,0 +1,16 @@
+{
+  "file": "test/async.js",
+  "contents": "(The value of this property is over-sized, so it is validated independently.)",
+  "attrs": {
+    "description": "Async test",
+    "flags": {
+      "async": true
+    },
+    "includes": [
+      "assert.js"
+    ]
+  },
+  "copyright": "",
+  "scenario": "default",
+  "insertionIndex": 890
+}

--- a/test/collateral/valid-default/expected-metadata/test/async_strict_mode.json
+++ b/test/collateral/valid-default/expected-metadata/test/async_strict_mode.json
@@ -1,0 +1,16 @@
+{
+  "file": "test/async.js",
+  "contents": "(The value of this property is over-sized, so it is validated independently.)",
+  "attrs": {
+    "description": "Async test (Strict Mode)",
+    "flags": {
+      "async": true
+    },
+    "includes": [
+      "assert.js"
+    ]
+  },
+  "copyright": "",
+  "scenario": "strict mode",
+  "insertionIndex": 904
+}

--- a/test/collateral/valid-default/expected-metadata/test/bothStrict_default.json
+++ b/test/collateral/valid-default/expected-metadata/test/bothStrict_default.json
@@ -1,0 +1,23 @@
+{
+  "file": "test/bothStrict.js",
+  "contents": "(The value of this property is over-sized, so it is validated independently.)",
+  "attrs": {
+    "description": "Should test in both modes",
+    "features": [
+      "var",
+      "try",
+      "if"
+    ],
+    "negative": {
+      "phase": "runtime",
+      "type": "ReferenceError"
+    },
+    "flags": {},
+    "includes": [
+      "assert.js"
+    ]
+  },
+  "copyright": "",
+  "scenario": "default",
+  "insertionIndex": 890
+}

--- a/test/collateral/valid-default/expected-metadata/test/bothStrict_strict_mode.json
+++ b/test/collateral/valid-default/expected-metadata/test/bothStrict_strict_mode.json
@@ -1,0 +1,23 @@
+{
+  "file": "test/bothStrict.js",
+  "contents": "(The value of this property is over-sized, so it is validated independently.)",
+  "attrs": {
+    "description": "Should test in both modes (Strict Mode)",
+    "features": [
+      "var",
+      "try",
+      "if"
+    ],
+    "negative": {
+      "phase": "runtime",
+      "type": "ReferenceError"
+    },
+    "flags": {},
+    "includes": [
+      "assert.js"
+    ]
+  },
+  "copyright": "",
+  "scenario": "strict mode",
+  "insertionIndex": 904
+}

--- a/test/collateral/valid-default/expected-metadata/test/error_default.json
+++ b/test/collateral/valid-default/expected-metadata/test/error_default.json
@@ -1,0 +1,18 @@
+{
+  "file": "test/error.js",
+  "contents": "(The value of this property is over-sized, so it is validated independently.)",
+  "attrs": {
+    "description": "Fails by calling $ERROR",
+    "negative": {
+      "phase": "runtime",
+      "type": "Test262Error"
+    },
+    "flags": {},
+    "includes": [
+      "assert.js"
+    ]
+  },
+  "copyright": "",
+  "scenario": "default",
+  "insertionIndex": 890
+}

--- a/test/collateral/valid-default/expected-metadata/test/error_strict_mode.json
+++ b/test/collateral/valid-default/expected-metadata/test/error_strict_mode.json
@@ -1,0 +1,18 @@
+{
+  "file": "test/error.js",
+  "contents": "(The value of this property is over-sized, so it is validated independently.)",
+  "attrs": {
+    "description": "Fails by calling $ERROR (Strict Mode)",
+    "negative": {
+      "phase": "runtime",
+      "type": "Test262Error"
+    },
+    "flags": {},
+    "includes": [
+      "assert.js"
+    ]
+  },
+  "copyright": "",
+  "scenario": "strict mode",
+  "insertionIndex": 904
+}

--- a/test/collateral/valid-default/expected-metadata/test/module_default.json
+++ b/test/collateral/valid-default/expected-metadata/test/module_default.json
@@ -1,0 +1,16 @@
+{
+  "file": "test/module.js",
+  "contents": "(The value of this property is over-sized, so it is validated independently.)",
+  "attrs": {
+    "description": "A test for module code",
+    "flags": {
+      "module": true
+    },
+    "includes": [
+      "assert.js"
+    ]
+  },
+  "copyright": "",
+  "scenario": "default",
+  "insertionIndex": 890
+}

--- a/test/collateral/valid-default/expected-metadata/test/module_strict_mode.json
+++ b/test/collateral/valid-default/expected-metadata/test/module_strict_mode.json
@@ -1,0 +1,16 @@
+{
+  "file": "test/module.js",
+  "contents": "(The value of this property is over-sized, so it is validated independently.)",
+  "attrs": {
+    "description": "A test for module code (Strict Mode)",
+    "flags": {
+      "module": true
+    },
+    "includes": [
+      "assert.js"
+    ]
+  },
+  "copyright": "",
+  "scenario": "strict mode",
+  "insertionIndex": 904
+}

--- a/test/collateral/valid-default/expected-metadata/test/negative-empty_default.json
+++ b/test/collateral/valid-default/expected-metadata/test/negative-empty_default.json
@@ -1,0 +1,18 @@
+{
+  "file": "test/negative-empty.js",
+  "contents": "(The value of this property is over-sized, so it is validated independently.)",
+  "attrs": {
+    "description": "Should report the expected error indicated by the \"negative\" frontmatter",
+    "negative": {
+      "phase": "runtime",
+      "type": "Test262Error"
+    },
+    "flags": {},
+    "includes": [
+      "assert.js"
+    ]
+  },
+  "copyright": "",
+  "scenario": "default",
+  "insertionIndex": 890
+}

--- a/test/collateral/valid-default/expected-metadata/test/negative-empty_strict_mode.json
+++ b/test/collateral/valid-default/expected-metadata/test/negative-empty_strict_mode.json
@@ -1,0 +1,18 @@
+{
+  "file": "test/negative-empty.js",
+  "contents": "(The value of this property is over-sized, so it is validated independently.)",
+  "attrs": {
+    "description": "Should report the expected error indicated by the \"negative\" frontmatter (Strict Mode)",
+    "negative": {
+      "phase": "runtime",
+      "type": "Test262Error"
+    },
+    "flags": {},
+    "includes": [
+      "assert.js"
+    ]
+  },
+  "copyright": "",
+  "scenario": "strict mode",
+  "insertionIndex": 904
+}

--- a/test/collateral/valid-default/expected-metadata/test/noStrict_default.json
+++ b/test/collateral/valid-default/expected-metadata/test/noStrict_default.json
@@ -1,0 +1,16 @@
+{
+  "file": "test/noStrict.js",
+  "contents": "(The value of this property is over-sized, so it is validated independently.)",
+  "attrs": {
+    "description": "Should not test in strict mode",
+    "flags": {
+      "noStrict": true
+    },
+    "includes": [
+      "assert.js"
+    ]
+  },
+  "copyright": "",
+  "scenario": "default",
+  "insertionIndex": 890
+}

--- a/test/collateral/valid-default/expected-metadata/test/rawNoStrict_default.json
+++ b/test/collateral/valid-default/expected-metadata/test/rawNoStrict_default.json
@@ -1,0 +1,14 @@
+{
+  "file": "test/rawNoStrict.js",
+  "contents": "(The value of this property is over-sized, so it is validated independently.)",
+  "attrs": {
+    "description": "Should not test in strict mode",
+    "flags": {
+      "raw": true
+    },
+    "includes": []
+  },
+  "copyright": "",
+  "scenario": "default",
+  "insertionIndex": -1
+}

--- a/test/collateral/valid-default/expected-metadata/test/rawStrict_default.json
+++ b/test/collateral/valid-default/expected-metadata/test/rawStrict_default.json
@@ -1,0 +1,14 @@
+{
+  "file": "test/rawStrict.js",
+  "contents": "(The value of this property is over-sized, so it is validated independently.)",
+  "attrs": {
+    "description": "Should not test in strict mode (but allow strict mode to be enabled)",
+    "flags": {
+      "raw": true
+    },
+    "includes": []
+  },
+  "copyright": "",
+  "scenario": "default",
+  "insertionIndex": -1
+}

--- a/test/collateral/valid-default/expected-metadata/test/strict_strict_mode.json
+++ b/test/collateral/valid-default/expected-metadata/test/strict_strict_mode.json
@@ -1,0 +1,20 @@
+{
+  "file": "test/strict.js",
+  "contents": "(The value of this property is over-sized, so it is validated independently.)",
+  "attrs": {
+    "description": "Should not test in sloppy mode",
+    "flags": {
+      "onlyStrict": true
+    },
+    "negative": {
+      "phase": "runtime",
+      "type": "ReferenceError"
+    },
+    "includes": [
+      "assert.js"
+    ]
+  },
+  "copyright": "",
+  "scenario": "strict mode",
+  "insertionIndex": 904
+}

--- a/test/collateral/valid-default/fake-test262/harness/assert.js
+++ b/test/collateral/valid-default/fake-test262/harness/assert.js
@@ -1,0 +1,17 @@
+// This is assert.js
+
+'It has some contents';
+
+/* that
+ *
+ * should
+
+ * not
+ */
+
+`be ${ "modified" }`;
+
+var including, trailing;
+whitespace: ;                    
+
+void "end of assert.js";

--- a/test/collateral/valid-default/fake-test262/test/async.js
+++ b/test/collateral/valid-default/fake-test262/test/async.js
@@ -1,0 +1,10 @@
+/*---
+description: Async test
+flags: [async]
+---*/
+
+var p = new Promise(function(resolve) {
+  resolve();
+});
+
+p.then($DONE, $DONE);

--- a/test/collateral/valid-default/fake-test262/test/asyncNegative.js
+++ b/test/collateral/valid-default/fake-test262/test/asyncNegative.js
@@ -1,0 +1,11 @@
+/*---
+description: Async negative test
+negative:
+  phase: runtime
+  type: RangeError
+flags: [async]
+---*/
+
+setTimeout(function() {
+  $DONE(new RangeError());
+}, 1000);

--- a/test/collateral/valid-default/fake-test262/test/bothStrict.js
+++ b/test/collateral/valid-default/fake-test262/test/bothStrict.js
@@ -1,0 +1,15 @@
+/*---
+description: Should test in both modes
+features: [var, try, if]
+negative:
+  phase: runtime
+  type: ReferenceError
+---*/
+var strict;
+try { x = 1; strict = false;} catch(e) { strict = true }
+
+if(strict) {
+    y = 1;
+} else {
+    throw new ReferenceError();
+}

--- a/test/collateral/valid-default/fake-test262/test/error.js
+++ b/test/collateral/valid-default/fake-test262/test/error.js
@@ -1,0 +1,8 @@
+/*---
+description: Fails by calling $ERROR
+negative:
+  phase: runtime
+  type: Test262Error
+---*/
+
+$ERROR('failure message');

--- a/test/collateral/valid-default/fake-test262/test/module.js
+++ b/test/collateral/valid-default/fake-test262/test/module.js
@@ -1,0 +1,6 @@
+/*---
+description: A test for module code
+flags: [module]
+---*/
+
+import fixture from './module_FIXTURE.js';

--- a/test/collateral/valid-default/fake-test262/test/module_FIXTURE.js
+++ b/test/collateral/valid-default/fake-test262/test/module_FIXTURE.js
@@ -1,0 +1,2 @@
+// This file is a Test262 "fixture" file and should not be
+// visited.

--- a/test/collateral/valid-default/fake-test262/test/negative-empty.js
+++ b/test/collateral/valid-default/fake-test262/test/negative-empty.js
@@ -1,0 +1,6 @@
+/*---
+description: Should report the expected error indicated by the "negative" frontmatter
+negative:
+  phase: runtime
+  type: Test262Error
+---*/

--- a/test/collateral/valid-default/fake-test262/test/noStrict.js
+++ b/test/collateral/valid-default/fake-test262/test/noStrict.js
@@ -1,0 +1,5 @@
+/*---
+description: Should not test in strict mode
+flags: [noStrict]
+---*/
+x = 5;

--- a/test/collateral/valid-default/fake-test262/test/rawNoStrict.js
+++ b/test/collateral/valid-default/fake-test262/test/rawNoStrict.js
@@ -1,0 +1,14 @@
+/*---
+description: Should not test in strict mode
+flags: [raw]
+---*/
+var seemsStrict;
+try {
+  x = 1;
+} catch (err) {
+  seemsStrict = err.constructor === ReferenceError;
+}
+
+if (seemsStrict) {
+  throw new Error('Script erroneously interpreted in strict mode.');
+}

--- a/test/collateral/valid-default/fake-test262/test/rawStrict.js
+++ b/test/collateral/valid-default/fake-test262/test/rawStrict.js
@@ -1,0 +1,15 @@
+/*---
+description: Should not test in strict mode (but allow strict mode to be enabled)
+flags: [raw]
+---*/
+'use strict';
+var seemsStrict;
+try {
+  x = 1;
+} catch (err) {
+  seemsStrict = err.constructor === ReferenceError;
+}
+
+if (!seemsStrict) {
+  throw new Error('Script erroneously not interpreted in strict mode.');
+}

--- a/test/collateral/valid-default/fake-test262/test/strict.js
+++ b/test/collateral/valid-default/fake-test262/test/strict.js
@@ -1,0 +1,9 @@
+/*---
+description: Should not test in sloppy mode
+flags: [onlyStrict]
+negative:
+  phase: runtime
+  type: ReferenceError
+---*/
+x = 5;
+$ERROR('Not in strict mode');

--- a/test/collateral/valid-with-includes/custom-includes/assert.js
+++ b/test/collateral/valid-with-includes/custom-includes/assert.js
@@ -1,0 +1,17 @@
+// This is a CUSTOM assert.js
+
+'It has some CUSTOM contents';
+
+/* that
+ *
+ * should
+
+ * not
+ */
+
+`be ${ "modified" }`;
+
+var including, CUSTOM, trailing;
+whitespace: ;                    
+
+void "end of CUSTOM assert.js";

--- a/test/collateral/valid-with-includes/expected-content/test/bothStrict_default.js
+++ b/test/collateral/valid-with-includes/expected-content/test/bothStrict_default.js
@@ -1,0 +1,63 @@
+function Test262Error(message) {
+    if (message) this.message = message;
+}
+
+Test262Error.prototype.name = "Test262Error";
+
+Test262Error.prototype.toString = function () {
+    return "Test262Error: " + this.message;
+};
+
+function $ERROR(err) {
+  if(typeof err === "object" && err !== null && "name" in err) {
+      throw err;
+  } else {
+    throw new Test262Error(err);
+  }
+}
+
+function $DONE(err) {
+  if (err) {
+    if(typeof err === "object" && err !== null && "name" in err) {
+      print('test262/error ' + err.name + ': ' + err.message);
+    } else {
+      print('test262/error Test262Error: ' + err);
+    }
+  }
+  print('test262/done');
+  $262.destroy();
+}
+
+function $LOG(str) {
+  print(str);
+}
+
+
+// This is a CUSTOM assert.js
+
+'It has some CUSTOM contents';
+
+/* that
+ *
+ * should
+
+ * not
+ */
+
+`be ${ "modified" }`;
+
+var including, CUSTOM, trailing;
+whitespace: ;                    
+
+void "end of CUSTOM assert.js";
+
+var strict;
+try { x = 1; strict = false;} catch(e) { strict = true }
+
+if(strict) {
+    y = 1;
+} else {
+    throw new ReferenceError();
+}
+
+;$DONE();

--- a/test/collateral/valid-with-includes/expected-content/test/bothStrict_strict_mode.js
+++ b/test/collateral/valid-with-includes/expected-content/test/bothStrict_strict_mode.js
@@ -1,0 +1,64 @@
+"use strict";
+function Test262Error(message) {
+    if (message) this.message = message;
+}
+
+Test262Error.prototype.name = "Test262Error";
+
+Test262Error.prototype.toString = function () {
+    return "Test262Error: " + this.message;
+};
+
+function $ERROR(err) {
+  if(typeof err === "object" && err !== null && "name" in err) {
+      throw err;
+  } else {
+    throw new Test262Error(err);
+  }
+}
+
+function $DONE(err) {
+  if (err) {
+    if(typeof err === "object" && err !== null && "name" in err) {
+      print('test262/error ' + err.name + ': ' + err.message);
+    } else {
+      print('test262/error Test262Error: ' + err);
+    }
+  }
+  print('test262/done');
+  $262.destroy();
+}
+
+function $LOG(str) {
+  print(str);
+}
+
+
+// This is a CUSTOM assert.js
+
+'It has some CUSTOM contents';
+
+/* that
+ *
+ * should
+
+ * not
+ */
+
+`be ${ "modified" }`;
+
+var including, CUSTOM, trailing;
+whitespace: ;                    
+
+void "end of CUSTOM assert.js";
+
+var strict;
+try { x = 1; strict = false;} catch(e) { strict = true }
+
+if(strict) {
+    y = 1;
+} else {
+    throw new ReferenceError();
+}
+
+;$DONE();

--- a/test/collateral/valid-with-includes/expected-metadata/test/bothStrict_default.json
+++ b/test/collateral/valid-with-includes/expected-metadata/test/bothStrict_default.json
@@ -1,0 +1,23 @@
+{
+  "file": "test/bothStrict.js",
+  "contents": "(The value of this property is over-sized, so it is validated independently.)",
+  "attrs": {
+    "description": "Should test in both modes",
+    "features": [
+      "var",
+      "try",
+      "if"
+    ],
+    "negative": {
+      "phase": "runtime",
+      "type": "ReferenceError"
+    },
+    "flags": {},
+    "includes": [
+      "assert.js"
+    ]
+  },
+  "copyright": "",
+  "scenario": "default",
+  "insertionIndex": 921
+}

--- a/test/collateral/valid-with-includes/expected-metadata/test/bothStrict_strict_mode.json
+++ b/test/collateral/valid-with-includes/expected-metadata/test/bothStrict_strict_mode.json
@@ -1,0 +1,23 @@
+{
+  "file": "test/bothStrict.js",
+  "contents": "(The value of this property is over-sized, so it is validated independently.)",
+  "attrs": {
+    "description": "Should test in both modes (Strict Mode)",
+    "features": [
+      "var",
+      "try",
+      "if"
+    ],
+    "negative": {
+      "phase": "runtime",
+      "type": "ReferenceError"
+    },
+    "flags": {},
+    "includes": [
+      "assert.js"
+    ]
+  },
+  "copyright": "",
+  "scenario": "strict mode",
+  "insertionIndex": 935
+}

--- a/test/collateral/valid-with-includes/fake-test262/harness/assert.js
+++ b/test/collateral/valid-with-includes/fake-test262/harness/assert.js
@@ -1,0 +1,17 @@
+// This is assert.js
+
+'It has some contents';
+
+/* that
+ *
+ * should
+
+ * not
+ */
+
+`be ${ "modified" }`;
+
+var including, trailing;
+whitespace: ;                    
+
+void "end of assert.js";

--- a/test/collateral/valid-with-includes/fake-test262/test/bothStrict.js
+++ b/test/collateral/valid-with-includes/fake-test262/test/bothStrict.js
@@ -1,0 +1,15 @@
+/*---
+description: Should test in both modes
+features: [var, try, if]
+negative:
+  phase: runtime
+  type: ReferenceError
+---*/
+var strict;
+try { x = 1; strict = false;} catch(e) { strict = true }
+
+if(strict) {
+    y = 1;
+} else {
+    throw new ReferenceError();
+}

--- a/test/collateral/valid-with-paths/expected-content/test/async/asyncNegative_default.js
+++ b/test/collateral/valid-with-paths/expected-content/test/async/asyncNegative_default.js
@@ -1,0 +1,57 @@
+function Test262Error(message) {
+    if (message) this.message = message;
+}
+
+Test262Error.prototype.name = "Test262Error";
+
+Test262Error.prototype.toString = function () {
+    return "Test262Error: " + this.message;
+};
+
+function $ERROR(err) {
+  if(typeof err === "object" && err !== null && "name" in err) {
+      throw err;
+  } else {
+    throw new Test262Error(err);
+  }
+}
+
+function $DONE(err) {
+  if (err) {
+    if(typeof err === "object" && err !== null && "name" in err) {
+      print('test262/error ' + err.name + ': ' + err.message);
+    } else {
+      print('test262/error Test262Error: ' + err);
+    }
+  }
+  print('test262/done');
+  $262.destroy();
+}
+
+function $LOG(str) {
+  print(str);
+}
+
+
+// This is assert.js
+
+'It has some contents';
+
+/* that
+ *
+ * should
+
+ * not
+ */
+
+`be ${ "modified" }`;
+
+var including, trailing;
+whitespace: ;                    
+
+void "end of assert.js";
+
+
+setTimeout(function() {
+  $DONE(new RangeError());
+}, 1000);

--- a/test/collateral/valid-with-paths/expected-content/test/async/asyncNegative_strict_mode.js
+++ b/test/collateral/valid-with-paths/expected-content/test/async/asyncNegative_strict_mode.js
@@ -1,0 +1,58 @@
+"use strict";
+function Test262Error(message) {
+    if (message) this.message = message;
+}
+
+Test262Error.prototype.name = "Test262Error";
+
+Test262Error.prototype.toString = function () {
+    return "Test262Error: " + this.message;
+};
+
+function $ERROR(err) {
+  if(typeof err === "object" && err !== null && "name" in err) {
+      throw err;
+  } else {
+    throw new Test262Error(err);
+  }
+}
+
+function $DONE(err) {
+  if (err) {
+    if(typeof err === "object" && err !== null && "name" in err) {
+      print('test262/error ' + err.name + ': ' + err.message);
+    } else {
+      print('test262/error Test262Error: ' + err);
+    }
+  }
+  print('test262/done');
+  $262.destroy();
+}
+
+function $LOG(str) {
+  print(str);
+}
+
+
+// This is assert.js
+
+'It has some contents';
+
+/* that
+ *
+ * should
+
+ * not
+ */
+
+`be ${ "modified" }`;
+
+var including, trailing;
+whitespace: ;                    
+
+void "end of assert.js";
+
+
+setTimeout(function() {
+  $DONE(new RangeError());
+}, 1000);

--- a/test/collateral/valid-with-paths/expected-content/test/async/async_default.js
+++ b/test/collateral/valid-with-paths/expected-content/test/async/async_default.js
@@ -1,0 +1,59 @@
+function Test262Error(message) {
+    if (message) this.message = message;
+}
+
+Test262Error.prototype.name = "Test262Error";
+
+Test262Error.prototype.toString = function () {
+    return "Test262Error: " + this.message;
+};
+
+function $ERROR(err) {
+  if(typeof err === "object" && err !== null && "name" in err) {
+      throw err;
+  } else {
+    throw new Test262Error(err);
+  }
+}
+
+function $DONE(err) {
+  if (err) {
+    if(typeof err === "object" && err !== null && "name" in err) {
+      print('test262/error ' + err.name + ': ' + err.message);
+    } else {
+      print('test262/error Test262Error: ' + err);
+    }
+  }
+  print('test262/done');
+  $262.destroy();
+}
+
+function $LOG(str) {
+  print(str);
+}
+
+
+// This is assert.js
+
+'It has some contents';
+
+/* that
+ *
+ * should
+
+ * not
+ */
+
+`be ${ "modified" }`;
+
+var including, trailing;
+whitespace: ;                    
+
+void "end of assert.js";
+
+
+var p = new Promise(function(resolve) {
+  resolve();
+});
+
+p.then($DONE, $DONE);

--- a/test/collateral/valid-with-paths/expected-content/test/async/async_strict_mode.js
+++ b/test/collateral/valid-with-paths/expected-content/test/async/async_strict_mode.js
@@ -1,0 +1,60 @@
+"use strict";
+function Test262Error(message) {
+    if (message) this.message = message;
+}
+
+Test262Error.prototype.name = "Test262Error";
+
+Test262Error.prototype.toString = function () {
+    return "Test262Error: " + this.message;
+};
+
+function $ERROR(err) {
+  if(typeof err === "object" && err !== null && "name" in err) {
+      throw err;
+  } else {
+    throw new Test262Error(err);
+  }
+}
+
+function $DONE(err) {
+  if (err) {
+    if(typeof err === "object" && err !== null && "name" in err) {
+      print('test262/error ' + err.name + ': ' + err.message);
+    } else {
+      print('test262/error Test262Error: ' + err);
+    }
+  }
+  print('test262/done');
+  $262.destroy();
+}
+
+function $LOG(str) {
+  print(str);
+}
+
+
+// This is assert.js
+
+'It has some contents';
+
+/* that
+ *
+ * should
+
+ * not
+ */
+
+`be ${ "modified" }`;
+
+var including, trailing;
+whitespace: ;                    
+
+void "end of assert.js";
+
+
+var p = new Promise(function(resolve) {
+  resolve();
+});
+
+p.then($DONE, $DONE);

--- a/test/collateral/valid-with-paths/expected-content/test/bothStrict_default.js
+++ b/test/collateral/valid-with-paths/expected-content/test/bothStrict_default.js
@@ -1,0 +1,63 @@
+function Test262Error(message) {
+    if (message) this.message = message;
+}
+
+Test262Error.prototype.name = "Test262Error";
+
+Test262Error.prototype.toString = function () {
+    return "Test262Error: " + this.message;
+};
+
+function $ERROR(err) {
+  if(typeof err === "object" && err !== null && "name" in err) {
+      throw err;
+  } else {
+    throw new Test262Error(err);
+  }
+}
+
+function $DONE(err) {
+  if (err) {
+    if(typeof err === "object" && err !== null && "name" in err) {
+      print('test262/error ' + err.name + ': ' + err.message);
+    } else {
+      print('test262/error Test262Error: ' + err);
+    }
+  }
+  print('test262/done');
+  $262.destroy();
+}
+
+function $LOG(str) {
+  print(str);
+}
+
+
+// This is assert.js
+
+'It has some contents';
+
+/* that
+ *
+ * should
+
+ * not
+ */
+
+`be ${ "modified" }`;
+
+var including, trailing;
+whitespace: ;                    
+
+void "end of assert.js";
+
+var strict;
+try { x = 1; strict = false;} catch(e) { strict = true }
+
+if(strict) {
+    y = 1;
+} else {
+    throw new ReferenceError();
+}
+
+;$DONE();

--- a/test/collateral/valid-with-paths/expected-content/test/bothStrict_strict_mode.js
+++ b/test/collateral/valid-with-paths/expected-content/test/bothStrict_strict_mode.js
@@ -1,0 +1,64 @@
+"use strict";
+function Test262Error(message) {
+    if (message) this.message = message;
+}
+
+Test262Error.prototype.name = "Test262Error";
+
+Test262Error.prototype.toString = function () {
+    return "Test262Error: " + this.message;
+};
+
+function $ERROR(err) {
+  if(typeof err === "object" && err !== null && "name" in err) {
+      throw err;
+  } else {
+    throw new Test262Error(err);
+  }
+}
+
+function $DONE(err) {
+  if (err) {
+    if(typeof err === "object" && err !== null && "name" in err) {
+      print('test262/error ' + err.name + ': ' + err.message);
+    } else {
+      print('test262/error Test262Error: ' + err);
+    }
+  }
+  print('test262/done');
+  $262.destroy();
+}
+
+function $LOG(str) {
+  print(str);
+}
+
+
+// This is assert.js
+
+'It has some contents';
+
+/* that
+ *
+ * should
+
+ * not
+ */
+
+`be ${ "modified" }`;
+
+var including, trailing;
+whitespace: ;                    
+
+void "end of assert.js";
+
+var strict;
+try { x = 1; strict = false;} catch(e) { strict = true }
+
+if(strict) {
+    y = 1;
+} else {
+    throw new ReferenceError();
+}
+
+;$DONE();

--- a/test/collateral/valid-with-paths/expected-content/test/strict/no/noStrict_default.js
+++ b/test/collateral/valid-with-paths/expected-content/test/strict/no/noStrict_default.js
@@ -1,0 +1,56 @@
+function Test262Error(message) {
+    if (message) this.message = message;
+}
+
+Test262Error.prototype.name = "Test262Error";
+
+Test262Error.prototype.toString = function () {
+    return "Test262Error: " + this.message;
+};
+
+function $ERROR(err) {
+  if(typeof err === "object" && err !== null && "name" in err) {
+      throw err;
+  } else {
+    throw new Test262Error(err);
+  }
+}
+
+function $DONE(err) {
+  if (err) {
+    if(typeof err === "object" && err !== null && "name" in err) {
+      print('test262/error ' + err.name + ': ' + err.message);
+    } else {
+      print('test262/error Test262Error: ' + err);
+    }
+  }
+  print('test262/done');
+  $262.destroy();
+}
+
+function $LOG(str) {
+  print(str);
+}
+
+
+// This is assert.js
+
+'It has some contents';
+
+/* that
+ *
+ * should
+
+ * not
+ */
+
+`be ${ "modified" }`;
+
+var including, trailing;
+whitespace: ;                    
+
+void "end of assert.js";
+
+x = 5;
+
+;$DONE();

--- a/test/collateral/valid-with-paths/expected-content/test/strict/no/rawNoStrict_default.js
+++ b/test/collateral/valid-with-paths/expected-content/test/strict/no/rawNoStrict_default.js
@@ -1,0 +1,11 @@
+
+var seemsStrict;
+try {
+  x = 1;
+} catch (err) {
+  seemsStrict = err.constructor === ReferenceError;
+}
+
+if (seemsStrict) {
+  throw new Error('Script erroneously interpreted in strict mode.');
+}

--- a/test/collateral/valid-with-paths/expected-metadata/test/async/asyncNegative_default.json
+++ b/test/collateral/valid-with-paths/expected-metadata/test/async/asyncNegative_default.json
@@ -1,0 +1,20 @@
+{
+  "file": "test/async/asyncNegative.js",
+  "contents": "(The value of this property is over-sized, so it is validated independently.)",
+  "attrs": {
+    "description": "Async negative test",
+    "negative": {
+      "phase": "runtime",
+      "type": "RangeError"
+    },
+    "flags": {
+      "async": true
+    },
+    "includes": [
+      "assert.js"
+    ]
+  },
+  "copyright": "",
+  "scenario": "default",
+  "insertionIndex": 890
+}

--- a/test/collateral/valid-with-paths/expected-metadata/test/async/asyncNegative_strict_mode.json
+++ b/test/collateral/valid-with-paths/expected-metadata/test/async/asyncNegative_strict_mode.json
@@ -1,0 +1,20 @@
+{
+  "file": "test/async/asyncNegative.js",
+  "contents": "(The value of this property is over-sized, so it is validated independently.)",
+  "attrs": {
+    "description": "Async negative test (Strict Mode)",
+    "negative": {
+      "phase": "runtime",
+      "type": "RangeError"
+    },
+    "flags": {
+      "async": true
+    },
+    "includes": [
+      "assert.js"
+    ]
+  },
+  "copyright": "",
+  "scenario": "strict mode",
+  "insertionIndex": 904
+}

--- a/test/collateral/valid-with-paths/expected-metadata/test/async/async_default.json
+++ b/test/collateral/valid-with-paths/expected-metadata/test/async/async_default.json
@@ -1,0 +1,16 @@
+{
+  "file": "test/async/async.js",
+  "contents": "(The value of this property is over-sized, so it is validated independently.)",
+  "attrs": {
+    "description": "Async test",
+    "flags": {
+      "async": true
+    },
+    "includes": [
+      "assert.js"
+    ]
+  },
+  "copyright": "",
+  "scenario": "default",
+  "insertionIndex": 890
+}

--- a/test/collateral/valid-with-paths/expected-metadata/test/async/async_strict_mode.json
+++ b/test/collateral/valid-with-paths/expected-metadata/test/async/async_strict_mode.json
@@ -1,0 +1,16 @@
+{
+  "file": "test/async/async.js",
+  "contents": "(The value of this property is over-sized, so it is validated independently.)",
+  "attrs": {
+    "description": "Async test (Strict Mode)",
+    "flags": {
+      "async": true
+    },
+    "includes": [
+      "assert.js"
+    ]
+  },
+  "copyright": "",
+  "scenario": "strict mode",
+  "insertionIndex": 904
+}

--- a/test/collateral/valid-with-paths/expected-metadata/test/bothStrict_default.json
+++ b/test/collateral/valid-with-paths/expected-metadata/test/bothStrict_default.json
@@ -1,0 +1,23 @@
+{
+  "file": "test/bothStrict.js",
+  "contents": "(The value of this property is over-sized, so it is validated independently.)",
+  "attrs": {
+    "description": "Should test in both modes",
+    "features": [
+      "var",
+      "try",
+      "if"
+    ],
+    "negative": {
+      "phase": "runtime",
+      "type": "ReferenceError"
+    },
+    "flags": {},
+    "includes": [
+      "assert.js"
+    ]
+  },
+  "copyright": "",
+  "scenario": "default",
+  "insertionIndex": 890
+}

--- a/test/collateral/valid-with-paths/expected-metadata/test/bothStrict_strict_mode.json
+++ b/test/collateral/valid-with-paths/expected-metadata/test/bothStrict_strict_mode.json
@@ -1,0 +1,23 @@
+{
+  "file": "test/bothStrict.js",
+  "contents": "(The value of this property is over-sized, so it is validated independently.)",
+  "attrs": {
+    "description": "Should test in both modes (Strict Mode)",
+    "features": [
+      "var",
+      "try",
+      "if"
+    ],
+    "negative": {
+      "phase": "runtime",
+      "type": "ReferenceError"
+    },
+    "flags": {},
+    "includes": [
+      "assert.js"
+    ]
+  },
+  "copyright": "",
+  "scenario": "strict mode",
+  "insertionIndex": 904
+}

--- a/test/collateral/valid-with-paths/expected-metadata/test/strict/no/noStrict_default.json
+++ b/test/collateral/valid-with-paths/expected-metadata/test/strict/no/noStrict_default.json
@@ -1,0 +1,16 @@
+{
+  "file": "test/strict/no/noStrict.js",
+  "contents": "(The value of this property is over-sized, so it is validated independently.)",
+  "attrs": {
+    "description": "Should not test in strict mode",
+    "flags": {
+      "noStrict": true
+    },
+    "includes": [
+      "assert.js"
+    ]
+  },
+  "copyright": "",
+  "scenario": "default",
+  "insertionIndex": 890
+}

--- a/test/collateral/valid-with-paths/expected-metadata/test/strict/no/rawNoStrict_default.json
+++ b/test/collateral/valid-with-paths/expected-metadata/test/strict/no/rawNoStrict_default.json
@@ -1,0 +1,14 @@
+{
+  "file": "test/strict/no/rawNoStrict.js",
+  "contents": "(The value of this property is over-sized, so it is validated independently.)",
+  "attrs": {
+    "description": "Should not test in strict mode",
+    "flags": {
+      "raw": true
+    },
+    "includes": []
+  },
+  "copyright": "",
+  "scenario": "default",
+  "insertionIndex": -1
+}

--- a/test/collateral/valid-with-paths/fake-test262/harness/assert.js
+++ b/test/collateral/valid-with-paths/fake-test262/harness/assert.js
@@ -1,0 +1,17 @@
+// This is assert.js
+
+'It has some contents';
+
+/* that
+ *
+ * should
+
+ * not
+ */
+
+`be ${ "modified" }`;
+
+var including, trailing;
+whitespace: ;                    
+
+void "end of assert.js";

--- a/test/collateral/valid-with-paths/fake-test262/test/async/async.js
+++ b/test/collateral/valid-with-paths/fake-test262/test/async/async.js
@@ -1,0 +1,10 @@
+/*---
+description: Async test
+flags: [async]
+---*/
+
+var p = new Promise(function(resolve) {
+  resolve();
+});
+
+p.then($DONE, $DONE);

--- a/test/collateral/valid-with-paths/fake-test262/test/async/asyncNegative.js
+++ b/test/collateral/valid-with-paths/fake-test262/test/async/asyncNegative.js
@@ -1,0 +1,11 @@
+/*---
+description: Async negative test
+negative:
+  phase: runtime
+  type: RangeError
+flags: [async]
+---*/
+
+setTimeout(function() {
+  $DONE(new RangeError());
+}, 1000);

--- a/test/collateral/valid-with-paths/fake-test262/test/bothStrict.js
+++ b/test/collateral/valid-with-paths/fake-test262/test/bothStrict.js
@@ -1,0 +1,15 @@
+/*---
+description: Should test in both modes
+features: [var, try, if]
+negative:
+  phase: runtime
+  type: ReferenceError
+---*/
+var strict;
+try { x = 1; strict = false;} catch(e) { strict = true }
+
+if(strict) {
+    y = 1;
+} else {
+    throw new ReferenceError();
+}

--- a/test/collateral/valid-with-paths/fake-test262/test/error.js
+++ b/test/collateral/valid-with-paths/fake-test262/test/error.js
@@ -1,0 +1,8 @@
+/*---
+description: Fails by calling $ERROR
+negative:
+  phase: runtime
+  type: Test262Error
+---*/
+
+$ERROR('failure message');

--- a/test/collateral/valid-with-paths/fake-test262/test/negative-empty.js
+++ b/test/collateral/valid-with-paths/fake-test262/test/negative-empty.js
@@ -1,0 +1,6 @@
+/*---
+description: Should report the expected error indicated by the "negative" frontmatter
+negative:
+  phase: runtime
+  type: Test262Error
+---*/

--- a/test/collateral/valid-with-paths/fake-test262/test/strict/no/noStrict.js
+++ b/test/collateral/valid-with-paths/fake-test262/test/strict/no/noStrict.js
@@ -1,0 +1,5 @@
+/*---
+description: Should not test in strict mode
+flags: [noStrict]
+---*/
+x = 5;

--- a/test/collateral/valid-with-paths/fake-test262/test/strict/no/rawNoStrict.js
+++ b/test/collateral/valid-with-paths/fake-test262/test/strict/no/rawNoStrict.js
@@ -1,0 +1,14 @@
+/*---
+description: Should not test in strict mode
+flags: [raw]
+---*/
+var seemsStrict;
+try {
+  x = 1;
+} catch (err) {
+  seemsStrict = err.constructor === ReferenceError;
+}
+
+if (seemsStrict) {
+  throw new Error('Script erroneously interpreted in strict mode.');
+}

--- a/test/collateral/valid-with-paths/fake-test262/test/strict/rawStrict.js
+++ b/test/collateral/valid-with-paths/fake-test262/test/strict/rawStrict.js
@@ -1,0 +1,15 @@
+/*---
+description: Should not test in strict mode (but allow strict mode to be enabled)
+flags: [raw]
+---*/
+'use strict';
+var seemsStrict;
+try {
+  x = 1;
+} catch (err) {
+  seemsStrict = err.constructor === ReferenceError;
+}
+
+if (!seemsStrict) {
+  throw new Error('Script erroneously not interpreted in strict mode.');
+}

--- a/test/collateral/valid-with-paths/fake-test262/test/strict/strict.js
+++ b/test/collateral/valid-with-paths/fake-test262/test/strict/strict.js
@@ -1,0 +1,9 @@
+/*---
+description: Should not test in sloppy mode
+flags: [onlyStrict]
+negative:
+  phase: runtime
+  type: ReferenceError
+---*/
+x = 5;
+$ERROR('Not in strict mode');

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,167 @@
+'use strict';
+const fs = require('fs');
+const mkdirp = require('mkdirp');
+const path = require('path');
+const rimraf = require('rimraf');
+const tape = require('tape');
+
+const TestStream = require('..');
+const scenarios = /^(strict mode|default)$/;
+
+const RECORDING = !!process.env.RECORD;
+
+// Properties to exclude when validating metadata. The values are
+// inconsequential; they have been selected to aid in discoverability in the
+// programatically-generated "expectations" files.
+const blankOut = {
+  contents: '(The value of this property is over-sized, so it is validated independently.)'
+};
+
+function makeDataHandler(t, ids, fixtureDir) {
+  const test262Dir = path.join(fixtureDir, 'fake-test262');
+  const expectedContentDir = path.join(fixtureDir, 'expected-content');
+  const expectedMetadataDir = path.join(fixtureDir, 'expected-metadata');
+
+  if (RECORDING) {
+    rimraf.sync(expectedContentDir);
+    rimraf.sync(expectedMetadataDir);
+  }
+
+  return (test) => {
+    if (typeof test !== 'object' || test === null) {
+      t.ok(false, 'Emits object values');
+      return;
+    }
+
+    const actualContents = test.contents;
+    const actualMetadata = Object.assign({}, test, blankOut);
+
+    if (!fs.existsSync(path.join(test262Dir, test.file))) {
+      t.ok(false, 'Source file does not exist: ' + test.file);
+      return;
+    }
+
+    // `RegExp.prototype.test` acceptes `undefined`, so an explicit type
+    // check is necessary.
+    t.equal(typeof test.scenario, 'string', '`scenario` property is a string value');
+    t.ok(scenarios.test(test.scenario), '`scenario` property is a valid value');
+
+    const id = test.file.replace(/\.js$/, '_' + test.scenario.replace(' ', '_'));
+    const expectedContentFile = path.join(expectedContentDir, id) + '.js';
+    const expectedMetadataFile = path.join(expectedMetadataDir, id) + '.json';
+
+    t.not(ids.indexOf(id) === -1, 'Emits each test exactly once');
+    ids.push(id);
+
+    if (RECORDING) {
+      mkdirp.sync(path.dirname(expectedContentFile));
+      fs.writeFileSync(expectedContentFile, actualContents, 'utf-8');
+      mkdirp.sync(path.dirname(expectedMetadataFile));
+      fs.writeFileSync(expectedMetadataFile, JSON.stringify(actualMetadata, null, 2), 'utf-8');
+      return;
+    }
+
+    if (!fs.existsSync(expectedContentFile)) {
+      t.ok(false, 'Expected content file not found: ' + expectedContentFile);
+      return;
+    }
+
+    if (!fs.existsSync(expectedMetadataFile)) {
+      t.ok(false, 'Expected metadata file not found: ' + expectedMetadataFile);
+      return;
+    }
+
+    t.deepEqual(actualContents, fs.readFileSync(expectedContentFile, 'utf-8'));
+    t.deepEqual(actualMetadata, require(expectedMetadataFile));
+  };
+}
+
+tape('valid source directory', t => {
+  const fixtureDir = path.join(__dirname, 'collateral', 'valid-default');
+  const stream = new TestStream(path.join(fixtureDir, 'fake-test262'));
+  const ids = [];
+
+  stream.on('data', makeDataHandler(t, ids, fixtureDir));
+
+  stream.on('error', (error) => {
+    t.ok(error);
+    t.end(error);
+  });
+
+  stream.on('end', () => {
+    t.equal(ids.length, 16, 'Reports every available test');
+    t.end();
+  });
+});
+
+tape('valid source directory (with paths)', t => {
+  const fixtureDir = path.join(__dirname, 'collateral', 'valid-with-paths');
+  const paths = ['test/bothStrict.js', 'test/strict/no', 'test/async'];
+  const stream = new TestStream(path.join(fixtureDir, 'fake-test262'), { paths });
+  const ids = [];
+
+  stream.on('data', makeDataHandler(t, ids, fixtureDir));
+
+  stream.on('error', (error) => {
+    t.ok(error);
+    t.end(error);
+  });
+
+  stream.on('end', () => {
+    t.equal(ids.length, 8, 'Reports every available test');
+    t.end();
+  });
+});
+
+tape('valid source directory (with custom includes)', t => {
+  const fixtureDir = path.join(__dirname, 'collateral', 'valid-with-includes');
+  const includesDir = path.join(fixtureDir, 'custom-includes');
+  const stream = new TestStream(path.join(fixtureDir, 'fake-test262'), { includesDir });
+  const ids = [];
+
+  stream.on('data', makeDataHandler(t, ids, fixtureDir));
+
+  stream.on('error', (error) => {
+    t.ok(error);
+    t.end(error);
+  });
+
+  stream.on('end', () => {
+    t.equal(ids.length, 2, 'Reports every available test');
+    t.end();
+  });
+});
+
+tape('missing `assert.js`', t => {
+  const stream = new TestStream(path.join(__dirname, 'collateral', 'invalid-missing-harness'));
+
+  stream.on('data', () => {
+    t.end(new Error('Stream should not emit a `data` event'));
+  });
+
+  stream.on('end', () => {
+    t.end(new Error('Stream should not emit an `end` event'));
+  });
+
+  stream.on('error', (error) => {
+    t.ok(error, '`error` event should be published with an object');
+    t.end();
+  });
+});
+
+tape.skip('non-existent source directory', t => {
+  const stream = new TestStream(path.join(__dirname, 'collateral', 'this-directory-does-not-exist'));
+
+  stream.on('data', () => {
+    t.end(new Error('Stream should not emit a `data` event'));
+  });
+
+  stream.on('end', () => {
+    t.end(new Error('Stream should not emit an `end` event'));
+  });
+
+  stream.on('error', (error) => {
+    t.ok(error, '`error` event should be published with an object');
+    t.end();
+  });
+});


### PR DESCRIPTION
Hello @bterlson, @leobalter, @rwaldron, and @spectranaut. Here is my latest
attempt at the Node.js API for traversing Test262.

I've selected the BSD 3-Clause license in order to ensure compatibility with
`test262-harness` itself. Note that the licensee is Bocoup LLC because this is
almost entirely new work. One exception is the `create-scenarios.js` file,
which borrows heavily from a similar file in `test262-harness`. @bterlson is
this okay with you?

This module does *not* support file globbing. I think that kind of behavior is
much more high-level and best-provided by a CLI tool. Consumers of this module
who want more fine-grained filtering are free to do so by parsing the
`test.file` property of each "data" event.

Instead of re-implementing the `prelude` option as exposed by
`test262-harness`, I've extended the data model with a `insertionIndex`
property. Again, I thought this would be more fitting for a lower-level
utility. Instead of providing some static "prelude" string, consumers could
insert different content for each test.

I'd like to bring `test262-compiler` and `test262-parser` into this project.
Doing so would

- Allow for a more natural mechanism for deriving the `insertionIndex` (notice
  how hacky the current implementation is)
- Simplify maintenance (fewer packages to update to get fixes/features into
  `test262-harness`)
- Enable an additional option: `minimal`. This would limit all test
  modification to the bare minimum (as of today, just the insertion of a "use
  strict" directive). This would be of interest to consumers using Test262 to
  validate parsers because all the extra harness code injected into each test
  only serves to make parsing take longer
- Eliminate some noise in the source (see `compile.js` where the `async`,
  `isATest`, and `strictMode` properties are removed)

To prove all of this out, I've made a demonstration branch of
`test262-harness` where this implementation has been swapped in to place:

https://github.com/bterlson/test262-harness/compare/master...jugglinmike:test-stream-2?w=1

All the tests pass on that branch.

This project is only the first step in the process. JavaScript parsers will be
able to use this module directly, but it's not really appropriate for projects
that need to execute the code. What I would like to do after this is define a
minimal Node.js API for `test262-harness` that lets consumers interact with
this stream. In that way, projects like Babel could perform transformations on
the source code and then go on to execute the result in an actual runtime.

Here's what I could use from you folks:

- Do you think the design of this project is sound (especially the
  considerations described above)?
- Does the code itself look good to you?
- Do my planned "next steps" seem reasonable?

Thanks!