### PR TITLE
Make test source contents available on test object. Fixes gh-2

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -15,7 +15,7 @@ module.exports = function (filePath, options, done) {
       return;
     }
 
-    const raw = contents;
+    const source = contents;
 
     // The "compilation" process removes the tests' frontmatter, so a temporary
     // marker must be introduced so the insertion index can be identified
@@ -31,7 +31,7 @@ module.exports = function (filePath, options, done) {
         -1 : test.contents.indexOf(test262StreamMarker);
       test.contents = test.contents.replace(test262StreamMarker, '');
       test.file = path.relative(options.test262Dir, test.file);
-      test.raw = raw;
+      test.source = options.withSource ? source : null;
 
       // The following properties are provided by the `test262-parser` module,
       // they are inconsistent and possibly confusing.

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -15,7 +15,7 @@ module.exports = function (filePath, options, done) {
       return;
     }
 
-    const source = contents;
+    const raw = contents;
 
     // The "compilation" process removes the tests' frontmatter, so a temporary
     // marker must be introduced so the insertion index can be identified
@@ -31,7 +31,7 @@ module.exports = function (filePath, options, done) {
         -1 : test.contents.indexOf(test262StreamMarker);
       test.contents = test.contents.replace(test262StreamMarker, '');
       test.file = path.relative(options.test262Dir, test.file);
-      test.source = source;
+      test.raw = raw;
 
       // The following properties are provided by the `test262-parser` module,
       // they are inconsistent and possibly confusing.

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -15,6 +15,8 @@ module.exports = function (filePath, options, done) {
       return;
     }
 
+    const source = contents;
+
     // The "compilation" process removes the tests' frontmatter, so a temporary
     // marker must be introduced so the insertion index can be identified
     // following compilation.
@@ -28,8 +30,8 @@ module.exports = function (filePath, options, done) {
       test.insertionIndex = test.attrs.flags.raw ?
         -1 : test.contents.indexOf(test262StreamMarker);
       test.contents = test.contents.replace(test262StreamMarker, '');
-
       test.file = path.relative(options.test262Dir, test.file);
+      test.source = source;
 
       // The following properties are provided by the `test262-parser` module,
       // they are inconsistent and possibly confusing.

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,6 +21,8 @@ const fixturePattern = /_FIXTURE\.[jJ][sS]$/;
  *
  * - file {string} - the path to the file from which the test was derived,
  *                   relative to the provided Test262 directory
+ * - raw {string} - the complete source text for the test as it appears in
+ *                     test262/test/*
  * - contents {string} - the complete source text for the test; this contains
  *                       any "includes" files specified in the frontmatter,
  *                       "prelude" content if specified (see below), and any

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,8 +21,9 @@ const fixturePattern = /_FIXTURE\.[jJ][sS]$/;
  *
  * - file {string} - the path to the file from which the test was derived,
  *                   relative to the provided Test262 directory
- * - raw {string} - the complete source text for the test as it appears in
- *                     test262/test/*
+ * - source {string} - the complete _raw_ source text for the test as it appears in
+ *                     test262/test/*.
+ *                     Will be null if `withSource` is not explicitly set to `true`.
  * - contents {string} - the complete source text for the test; this contains
  *                       any "includes" files specified in the frontmatter,
  *                       "prelude" content if specified (see below), and any
@@ -44,6 +45,11 @@ const fixturePattern = /_FIXTURE\.[jJ][sS]$/;
  *                                         "includes" files (defaults to the
  *                                         appropriate subdirectory of the
  *                                         provided `test262Dir`
+ * @param {boolean} [options.withSource] - Defaults to `false`. When set to
+ *                                         `true`, the value of the `source`
+ *                                         property will be the complete
+ *                                         _raw_ source text for the test
+ *                                         as it appears in test262/test/*.
  * @param {Array<string>} [options.paths] - file system paths refining the set
  *                                          of tests that should be produced;
  *                                          only tests whose source file
@@ -71,7 +77,8 @@ module.exports = class TestStream extends Readable {
       .map(relativePath => path.join(test262Dir, relativePath));
     this[compileOpts] = {
       test262Dir,
-      includesDir: options.includesDir
+      includesDir: options.includesDir,
+      withSource: options.withSource ? true : false,
     };
     this[fileStream] = null;
     this[pendingOps] = 0;

--- a/test/collateral/valid-default/expected-metadata/test/asyncNegative_default.json
+++ b/test/collateral/valid-default/expected-metadata/test/asyncNegative_default.json
@@ -16,5 +16,6 @@
   },
   "copyright": "",
   "scenario": "default",
-  "insertionIndex": 890
+  "insertionIndex": 890,
+  "source": "/*---\ndescription: Async negative test\nnegative:\n  phase: runtime\n  type: RangeError\nflags: [async]\n---*/\n\nsetTimeout(function() {\n  $DONE(new RangeError());\n}, 1000);\n"
 }

--- a/test/collateral/valid-default/expected-metadata/test/asyncNegative_default.json
+++ b/test/collateral/valid-default/expected-metadata/test/asyncNegative_default.json
@@ -17,5 +17,5 @@
   "copyright": "",
   "scenario": "default",
   "insertionIndex": 890,
-  "source": "/*---\ndescription: Async negative test\nnegative:\n  phase: runtime\n  type: RangeError\nflags: [async]\n---*/\n\nsetTimeout(function() {\n  $DONE(new RangeError());\n}, 1000);\n"
+  "raw": "/*---\ndescription: Async negative test\nnegative:\n  phase: runtime\n  type: RangeError\nflags: [async]\n---*/\n\nsetTimeout(function() {\n  $DONE(new RangeError());\n}, 1000);\n"
 }

--- a/test/collateral/valid-default/expected-metadata/test/asyncNegative_default.json
+++ b/test/collateral/valid-default/expected-metadata/test/asyncNegative_default.json
@@ -17,5 +17,5 @@
   "copyright": "",
   "scenario": "default",
   "insertionIndex": 890,
-  "raw": "/*---\ndescription: Async negative test\nnegative:\n  phase: runtime\n  type: RangeError\nflags: [async]\n---*/\n\nsetTimeout(function() {\n  $DONE(new RangeError());\n}, 1000);\n"
+  "source": null
 }

--- a/test/collateral/valid-default/expected-metadata/test/asyncNegative_strict_mode.json
+++ b/test/collateral/valid-default/expected-metadata/test/asyncNegative_strict_mode.json
@@ -16,5 +16,6 @@
   },
   "copyright": "",
   "scenario": "strict mode",
-  "insertionIndex": 904
+  "insertionIndex": 904,
+  "source": "/*---\ndescription: Async negative test\nnegative:\n  phase: runtime\n  type: RangeError\nflags: [async]\n---*/\n\nsetTimeout(function() {\n  $DONE(new RangeError());\n}, 1000);\n"
 }

--- a/test/collateral/valid-default/expected-metadata/test/asyncNegative_strict_mode.json
+++ b/test/collateral/valid-default/expected-metadata/test/asyncNegative_strict_mode.json
@@ -17,5 +17,5 @@
   "copyright": "",
   "scenario": "strict mode",
   "insertionIndex": 904,
-  "source": "/*---\ndescription: Async negative test\nnegative:\n  phase: runtime\n  type: RangeError\nflags: [async]\n---*/\n\nsetTimeout(function() {\n  $DONE(new RangeError());\n}, 1000);\n"
+  "raw": "/*---\ndescription: Async negative test\nnegative:\n  phase: runtime\n  type: RangeError\nflags: [async]\n---*/\n\nsetTimeout(function() {\n  $DONE(new RangeError());\n}, 1000);\n"
 }

--- a/test/collateral/valid-default/expected-metadata/test/asyncNegative_strict_mode.json
+++ b/test/collateral/valid-default/expected-metadata/test/asyncNegative_strict_mode.json
@@ -17,5 +17,5 @@
   "copyright": "",
   "scenario": "strict mode",
   "insertionIndex": 904,
-  "raw": "/*---\ndescription: Async negative test\nnegative:\n  phase: runtime\n  type: RangeError\nflags: [async]\n---*/\n\nsetTimeout(function() {\n  $DONE(new RangeError());\n}, 1000);\n"
+  "source": null
 }

--- a/test/collateral/valid-default/expected-metadata/test/async_default.json
+++ b/test/collateral/valid-default/expected-metadata/test/async_default.json
@@ -13,5 +13,5 @@
   "copyright": "",
   "scenario": "default",
   "insertionIndex": 890,
-  "source": "/*---\ndescription: Async test\nflags: [async]\n---*/\n\nvar p = new Promise(function(resolve) {\n  resolve();\n});\n\np.then($DONE, $DONE);\n"
+  "raw": "/*---\ndescription: Async test\nflags: [async]\n---*/\n\nvar p = new Promise(function(resolve) {\n  resolve();\n});\n\np.then($DONE, $DONE);\n"
 }

--- a/test/collateral/valid-default/expected-metadata/test/async_default.json
+++ b/test/collateral/valid-default/expected-metadata/test/async_default.json
@@ -13,5 +13,5 @@
   "copyright": "",
   "scenario": "default",
   "insertionIndex": 890,
-  "raw": "/*---\ndescription: Async test\nflags: [async]\n---*/\n\nvar p = new Promise(function(resolve) {\n  resolve();\n});\n\np.then($DONE, $DONE);\n"
+  "source": null
 }

--- a/test/collateral/valid-default/expected-metadata/test/async_default.json
+++ b/test/collateral/valid-default/expected-metadata/test/async_default.json
@@ -12,5 +12,6 @@
   },
   "copyright": "",
   "scenario": "default",
-  "insertionIndex": 890
+  "insertionIndex": 890,
+  "source": "/*---\ndescription: Async test\nflags: [async]\n---*/\n\nvar p = new Promise(function(resolve) {\n  resolve();\n});\n\np.then($DONE, $DONE);\n"
 }

--- a/test/collateral/valid-default/expected-metadata/test/async_strict_mode.json
+++ b/test/collateral/valid-default/expected-metadata/test/async_strict_mode.json
@@ -13,5 +13,5 @@
   "copyright": "",
   "scenario": "strict mode",
   "insertionIndex": 904,
-  "raw": "/*---\ndescription: Async test\nflags: [async]\n---*/\n\nvar p = new Promise(function(resolve) {\n  resolve();\n});\n\np.then($DONE, $DONE);\n"
+  "source": null
 }

--- a/test/collateral/valid-default/expected-metadata/test/async_strict_mode.json
+++ b/test/collateral/valid-default/expected-metadata/test/async_strict_mode.json
@@ -13,5 +13,5 @@
   "copyright": "",
   "scenario": "strict mode",
   "insertionIndex": 904,
-  "source": "/*---\ndescription: Async test\nflags: [async]\n---*/\n\nvar p = new Promise(function(resolve) {\n  resolve();\n});\n\np.then($DONE, $DONE);\n"
+  "raw": "/*---\ndescription: Async test\nflags: [async]\n---*/\n\nvar p = new Promise(function(resolve) {\n  resolve();\n});\n\np.then($DONE, $DONE);\n"
 }

--- a/test/collateral/valid-default/expected-metadata/test/async_strict_mode.json
+++ b/test/collateral/valid-default/expected-metadata/test/async_strict_mode.json
@@ -12,5 +12,6 @@
   },
   "copyright": "",
   "scenario": "strict mode",
-  "insertionIndex": 904
+  "insertionIndex": 904,
+  "source": "/*---\ndescription: Async test\nflags: [async]\n---*/\n\nvar p = new Promise(function(resolve) {\n  resolve();\n});\n\np.then($DONE, $DONE);\n"
 }

--- a/test/collateral/valid-default/expected-metadata/test/bothStrict_default.json
+++ b/test/collateral/valid-default/expected-metadata/test/bothStrict_default.json
@@ -20,5 +20,5 @@
   "copyright": "",
   "scenario": "default",
   "insertionIndex": 890,
-  "raw": "/*---\ndescription: Should test in both modes\nfeatures: [var, try, if]\nnegative:\n  phase: runtime\n  type: ReferenceError\n---*/\nvar strict;\ntry { x = 1; strict = false;} catch(e) { strict = true }\n\nif(strict) {\n    y = 1;\n} else {\n    throw new ReferenceError();\n}\n"
+  "source": null
 }

--- a/test/collateral/valid-default/expected-metadata/test/bothStrict_default.json
+++ b/test/collateral/valid-default/expected-metadata/test/bothStrict_default.json
@@ -20,5 +20,5 @@
   "copyright": "",
   "scenario": "default",
   "insertionIndex": 890,
-  "source": "/*---\ndescription: Should test in both modes\nfeatures: [var, try, if]\nnegative:\n  phase: runtime\n  type: ReferenceError\n---*/\nvar strict;\ntry { x = 1; strict = false;} catch(e) { strict = true }\n\nif(strict) {\n    y = 1;\n} else {\n    throw new ReferenceError();\n}\n"
+  "raw": "/*---\ndescription: Should test in both modes\nfeatures: [var, try, if]\nnegative:\n  phase: runtime\n  type: ReferenceError\n---*/\nvar strict;\ntry { x = 1; strict = false;} catch(e) { strict = true }\n\nif(strict) {\n    y = 1;\n} else {\n    throw new ReferenceError();\n}\n"
 }

--- a/test/collateral/valid-default/expected-metadata/test/bothStrict_default.json
+++ b/test/collateral/valid-default/expected-metadata/test/bothStrict_default.json
@@ -19,5 +19,6 @@
   },
   "copyright": "",
   "scenario": "default",
-  "insertionIndex": 890
+  "insertionIndex": 890,
+  "source": "/*---\ndescription: Should test in both modes\nfeatures: [var, try, if]\nnegative:\n  phase: runtime\n  type: ReferenceError\n---*/\nvar strict;\ntry { x = 1; strict = false;} catch(e) { strict = true }\n\nif(strict) {\n    y = 1;\n} else {\n    throw new ReferenceError();\n}\n"
 }

--- a/test/collateral/valid-default/expected-metadata/test/bothStrict_strict_mode.json
+++ b/test/collateral/valid-default/expected-metadata/test/bothStrict_strict_mode.json
@@ -20,5 +20,5 @@
   "copyright": "",
   "scenario": "strict mode",
   "insertionIndex": 904,
-  "source": "/*---\ndescription: Should test in both modes\nfeatures: [var, try, if]\nnegative:\n  phase: runtime\n  type: ReferenceError\n---*/\nvar strict;\ntry { x = 1; strict = false;} catch(e) { strict = true }\n\nif(strict) {\n    y = 1;\n} else {\n    throw new ReferenceError();\n}\n"
+  "raw": "/*---\ndescription: Should test in both modes\nfeatures: [var, try, if]\nnegative:\n  phase: runtime\n  type: ReferenceError\n---*/\nvar strict;\ntry { x = 1; strict = false;} catch(e) { strict = true }\n\nif(strict) {\n    y = 1;\n} else {\n    throw new ReferenceError();\n}\n"
 }

--- a/test/collateral/valid-default/expected-metadata/test/bothStrict_strict_mode.json
+++ b/test/collateral/valid-default/expected-metadata/test/bothStrict_strict_mode.json
@@ -19,5 +19,6 @@
   },
   "copyright": "",
   "scenario": "strict mode",
-  "insertionIndex": 904
+  "insertionIndex": 904,
+  "source": "/*---\ndescription: Should test in both modes\nfeatures: [var, try, if]\nnegative:\n  phase: runtime\n  type: ReferenceError\n---*/\nvar strict;\ntry { x = 1; strict = false;} catch(e) { strict = true }\n\nif(strict) {\n    y = 1;\n} else {\n    throw new ReferenceError();\n}\n"
 }

--- a/test/collateral/valid-default/expected-metadata/test/error_default.json
+++ b/test/collateral/valid-default/expected-metadata/test/error_default.json
@@ -15,5 +15,5 @@
   "copyright": "",
   "scenario": "default",
   "insertionIndex": 890,
-  "raw": "/*---\ndescription: Fails by calling $ERROR\nnegative:\n  phase: runtime\n  type: Test262Error\n---*/\n\n$ERROR('failure message');\n"
+  "source": null
 }

--- a/test/collateral/valid-default/expected-metadata/test/error_default.json
+++ b/test/collateral/valid-default/expected-metadata/test/error_default.json
@@ -15,5 +15,5 @@
   "copyright": "",
   "scenario": "default",
   "insertionIndex": 890,
-  "source": "/*---\ndescription: Fails by calling $ERROR\nnegative:\n  phase: runtime\n  type: Test262Error\n---*/\n\n$ERROR('failure message');\n"
+  "raw": "/*---\ndescription: Fails by calling $ERROR\nnegative:\n  phase: runtime\n  type: Test262Error\n---*/\n\n$ERROR('failure message');\n"
 }

--- a/test/collateral/valid-default/expected-metadata/test/error_default.json
+++ b/test/collateral/valid-default/expected-metadata/test/error_default.json
@@ -14,5 +14,6 @@
   },
   "copyright": "",
   "scenario": "default",
-  "insertionIndex": 890
+  "insertionIndex": 890,
+  "source": "/*---\ndescription: Fails by calling $ERROR\nnegative:\n  phase: runtime\n  type: Test262Error\n---*/\n\n$ERROR('failure message');\n"
 }

--- a/test/collateral/valid-default/expected-metadata/test/error_strict_mode.json
+++ b/test/collateral/valid-default/expected-metadata/test/error_strict_mode.json
@@ -15,5 +15,5 @@
   "copyright": "",
   "scenario": "strict mode",
   "insertionIndex": 904,
-  "source": "/*---\ndescription: Fails by calling $ERROR\nnegative:\n  phase: runtime\n  type: Test262Error\n---*/\n\n$ERROR('failure message');\n"
+  "raw": "/*---\ndescription: Fails by calling $ERROR\nnegative:\n  phase: runtime\n  type: Test262Error\n---*/\n\n$ERROR('failure message');\n"
 }

--- a/test/collateral/valid-default/expected-metadata/test/error_strict_mode.json
+++ b/test/collateral/valid-default/expected-metadata/test/error_strict_mode.json
@@ -15,5 +15,5 @@
   "copyright": "",
   "scenario": "strict mode",
   "insertionIndex": 904,
-  "raw": "/*---\ndescription: Fails by calling $ERROR\nnegative:\n  phase: runtime\n  type: Test262Error\n---*/\n\n$ERROR('failure message');\n"
+  "source": null
 }

--- a/test/collateral/valid-default/expected-metadata/test/error_strict_mode.json
+++ b/test/collateral/valid-default/expected-metadata/test/error_strict_mode.json
@@ -14,5 +14,6 @@
   },
   "copyright": "",
   "scenario": "strict mode",
-  "insertionIndex": 904
+  "insertionIndex": 904,
+  "source": "/*---\ndescription: Fails by calling $ERROR\nnegative:\n  phase: runtime\n  type: Test262Error\n---*/\n\n$ERROR('failure message');\n"
 }

--- a/test/collateral/valid-default/expected-metadata/test/module_default.json
+++ b/test/collateral/valid-default/expected-metadata/test/module_default.json
@@ -13,5 +13,5 @@
   "copyright": "",
   "scenario": "default",
   "insertionIndex": 890,
-  "raw": "/*---\ndescription: A test for module code\nflags: [module]\n---*/\n\nimport fixture from './module_FIXTURE.js';\n"
+  "source": null
 }

--- a/test/collateral/valid-default/expected-metadata/test/module_default.json
+++ b/test/collateral/valid-default/expected-metadata/test/module_default.json
@@ -13,5 +13,5 @@
   "copyright": "",
   "scenario": "default",
   "insertionIndex": 890,
-  "source": "/*---\ndescription: A test for module code\nflags: [module]\n---*/\n\nimport fixture from './module_FIXTURE.js';\n"
+  "raw": "/*---\ndescription: A test for module code\nflags: [module]\n---*/\n\nimport fixture from './module_FIXTURE.js';\n"
 }

--- a/test/collateral/valid-default/expected-metadata/test/module_default.json
+++ b/test/collateral/valid-default/expected-metadata/test/module_default.json
@@ -12,5 +12,6 @@
   },
   "copyright": "",
   "scenario": "default",
-  "insertionIndex": 890
+  "insertionIndex": 890,
+  "source": "/*---\ndescription: A test for module code\nflags: [module]\n---*/\n\nimport fixture from './module_FIXTURE.js';\n"
 }

--- a/test/collateral/valid-default/expected-metadata/test/module_strict_mode.json
+++ b/test/collateral/valid-default/expected-metadata/test/module_strict_mode.json
@@ -13,5 +13,5 @@
   "copyright": "",
   "scenario": "strict mode",
   "insertionIndex": 904,
-  "raw": "/*---\ndescription: A test for module code\nflags: [module]\n---*/\n\nimport fixture from './module_FIXTURE.js';\n"
+  "source": null
 }

--- a/test/collateral/valid-default/expected-metadata/test/module_strict_mode.json
+++ b/test/collateral/valid-default/expected-metadata/test/module_strict_mode.json
@@ -12,5 +12,6 @@
   },
   "copyright": "",
   "scenario": "strict mode",
-  "insertionIndex": 904
+  "insertionIndex": 904,
+  "source": "/*---\ndescription: A test for module code\nflags: [module]\n---*/\n\nimport fixture from './module_FIXTURE.js';\n"
 }

--- a/test/collateral/valid-default/expected-metadata/test/module_strict_mode.json
+++ b/test/collateral/valid-default/expected-metadata/test/module_strict_mode.json
@@ -13,5 +13,5 @@
   "copyright": "",
   "scenario": "strict mode",
   "insertionIndex": 904,
-  "source": "/*---\ndescription: A test for module code\nflags: [module]\n---*/\n\nimport fixture from './module_FIXTURE.js';\n"
+  "raw": "/*---\ndescription: A test for module code\nflags: [module]\n---*/\n\nimport fixture from './module_FIXTURE.js';\n"
 }

--- a/test/collateral/valid-default/expected-metadata/test/negative-empty_default.json
+++ b/test/collateral/valid-default/expected-metadata/test/negative-empty_default.json
@@ -15,5 +15,5 @@
   "copyright": "",
   "scenario": "default",
   "insertionIndex": 890,
-  "source": "/*---\ndescription: Should report the expected error indicated by the \"negative\" frontmatter\nnegative:\n  phase: runtime\n  type: Test262Error\n---*/\n"
+  "raw": "/*---\ndescription: Should report the expected error indicated by the \"negative\" frontmatter\nnegative:\n  phase: runtime\n  type: Test262Error\n---*/\n"
 }

--- a/test/collateral/valid-default/expected-metadata/test/negative-empty_default.json
+++ b/test/collateral/valid-default/expected-metadata/test/negative-empty_default.json
@@ -14,5 +14,6 @@
   },
   "copyright": "",
   "scenario": "default",
-  "insertionIndex": 890
+  "insertionIndex": 890,
+  "source": "/*---\ndescription: Should report the expected error indicated by the \"negative\" frontmatter\nnegative:\n  phase: runtime\n  type: Test262Error\n---*/\n"
 }

--- a/test/collateral/valid-default/expected-metadata/test/negative-empty_default.json
+++ b/test/collateral/valid-default/expected-metadata/test/negative-empty_default.json
@@ -15,5 +15,5 @@
   "copyright": "",
   "scenario": "default",
   "insertionIndex": 890,
-  "raw": "/*---\ndescription: Should report the expected error indicated by the \"negative\" frontmatter\nnegative:\n  phase: runtime\n  type: Test262Error\n---*/\n"
+  "source": null
 }

--- a/test/collateral/valid-default/expected-metadata/test/negative-empty_strict_mode.json
+++ b/test/collateral/valid-default/expected-metadata/test/negative-empty_strict_mode.json
@@ -15,5 +15,5 @@
   "copyright": "",
   "scenario": "strict mode",
   "insertionIndex": 904,
-  "source": "/*---\ndescription: Should report the expected error indicated by the \"negative\" frontmatter\nnegative:\n  phase: runtime\n  type: Test262Error\n---*/\n"
+  "raw": "/*---\ndescription: Should report the expected error indicated by the \"negative\" frontmatter\nnegative:\n  phase: runtime\n  type: Test262Error\n---*/\n"
 }

--- a/test/collateral/valid-default/expected-metadata/test/negative-empty_strict_mode.json
+++ b/test/collateral/valid-default/expected-metadata/test/negative-empty_strict_mode.json
@@ -14,5 +14,6 @@
   },
   "copyright": "",
   "scenario": "strict mode",
-  "insertionIndex": 904
+  "insertionIndex": 904,
+  "source": "/*---\ndescription: Should report the expected error indicated by the \"negative\" frontmatter\nnegative:\n  phase: runtime\n  type: Test262Error\n---*/\n"
 }

--- a/test/collateral/valid-default/expected-metadata/test/negative-empty_strict_mode.json
+++ b/test/collateral/valid-default/expected-metadata/test/negative-empty_strict_mode.json
@@ -15,5 +15,5 @@
   "copyright": "",
   "scenario": "strict mode",
   "insertionIndex": 904,
-  "raw": "/*---\ndescription: Should report the expected error indicated by the \"negative\" frontmatter\nnegative:\n  phase: runtime\n  type: Test262Error\n---*/\n"
+  "source": null
 }

--- a/test/collateral/valid-default/expected-metadata/test/noStrict_default.json
+++ b/test/collateral/valid-default/expected-metadata/test/noStrict_default.json
@@ -13,5 +13,5 @@
   "copyright": "",
   "scenario": "default",
   "insertionIndex": 890,
-  "raw": "/*---\ndescription: Should not test in strict mode\nflags: [noStrict]\n---*/\nx = 5;\n"
+  "source": null
 }

--- a/test/collateral/valid-default/expected-metadata/test/noStrict_default.json
+++ b/test/collateral/valid-default/expected-metadata/test/noStrict_default.json
@@ -12,5 +12,6 @@
   },
   "copyright": "",
   "scenario": "default",
-  "insertionIndex": 890
+  "insertionIndex": 890,
+  "source": "/*---\ndescription: Should not test in strict mode\nflags: [noStrict]\n---*/\nx = 5;\n"
 }

--- a/test/collateral/valid-default/expected-metadata/test/noStrict_default.json
+++ b/test/collateral/valid-default/expected-metadata/test/noStrict_default.json
@@ -13,5 +13,5 @@
   "copyright": "",
   "scenario": "default",
   "insertionIndex": 890,
-  "source": "/*---\ndescription: Should not test in strict mode\nflags: [noStrict]\n---*/\nx = 5;\n"
+  "raw": "/*---\ndescription: Should not test in strict mode\nflags: [noStrict]\n---*/\nx = 5;\n"
 }

--- a/test/collateral/valid-default/expected-metadata/test/rawNoStrict_default.json
+++ b/test/collateral/valid-default/expected-metadata/test/rawNoStrict_default.json
@@ -10,5 +10,6 @@
   },
   "copyright": "",
   "scenario": "default",
-  "insertionIndex": -1
+  "insertionIndex": -1,
+  "source": "/*---\ndescription: Should not test in strict mode\nflags: [raw]\n---*/\nvar seemsStrict;\ntry {\n  x = 1;\n} catch (err) {\n  seemsStrict = err.constructor === ReferenceError;\n}\n\nif (seemsStrict) {\n  throw new Error('Script erroneously interpreted in strict mode.');\n}\n"
 }

--- a/test/collateral/valid-default/expected-metadata/test/rawNoStrict_default.json
+++ b/test/collateral/valid-default/expected-metadata/test/rawNoStrict_default.json
@@ -11,5 +11,5 @@
   "copyright": "",
   "scenario": "default",
   "insertionIndex": -1,
-  "source": "/*---\ndescription: Should not test in strict mode\nflags: [raw]\n---*/\nvar seemsStrict;\ntry {\n  x = 1;\n} catch (err) {\n  seemsStrict = err.constructor === ReferenceError;\n}\n\nif (seemsStrict) {\n  throw new Error('Script erroneously interpreted in strict mode.');\n}\n"
+  "raw": "/*---\ndescription: Should not test in strict mode\nflags: [raw]\n---*/\nvar seemsStrict;\ntry {\n  x = 1;\n} catch (err) {\n  seemsStrict = err.constructor === ReferenceError;\n}\n\nif (seemsStrict) {\n  throw new Error('Script erroneously interpreted in strict mode.');\n}\n"
 }

--- a/test/collateral/valid-default/expected-metadata/test/rawNoStrict_default.json
+++ b/test/collateral/valid-default/expected-metadata/test/rawNoStrict_default.json
@@ -11,5 +11,5 @@
   "copyright": "",
   "scenario": "default",
   "insertionIndex": -1,
-  "raw": "/*---\ndescription: Should not test in strict mode\nflags: [raw]\n---*/\nvar seemsStrict;\ntry {\n  x = 1;\n} catch (err) {\n  seemsStrict = err.constructor === ReferenceError;\n}\n\nif (seemsStrict) {\n  throw new Error('Script erroneously interpreted in strict mode.');\n}\n"
+  "source": null
 }

--- a/test/collateral/valid-default/expected-metadata/test/rawStrict_default.json
+++ b/test/collateral/valid-default/expected-metadata/test/rawStrict_default.json
@@ -11,5 +11,5 @@
   "copyright": "",
   "scenario": "default",
   "insertionIndex": -1,
-  "source": "/*---\ndescription: Should not test in strict mode (but allow strict mode to be enabled)\nflags: [raw]\n---*/\n'use strict';\nvar seemsStrict;\ntry {\n  x = 1;\n} catch (err) {\n  seemsStrict = err.constructor === ReferenceError;\n}\n\nif (!seemsStrict) {\n  throw new Error('Script erroneously not interpreted in strict mode.');\n}\n"
+  "raw": "/*---\ndescription: Should not test in strict mode (but allow strict mode to be enabled)\nflags: [raw]\n---*/\n'use strict';\nvar seemsStrict;\ntry {\n  x = 1;\n} catch (err) {\n  seemsStrict = err.constructor === ReferenceError;\n}\n\nif (!seemsStrict) {\n  throw new Error('Script erroneously not interpreted in strict mode.');\n}\n"
 }

--- a/test/collateral/valid-default/expected-metadata/test/rawStrict_default.json
+++ b/test/collateral/valid-default/expected-metadata/test/rawStrict_default.json
@@ -10,5 +10,6 @@
   },
   "copyright": "",
   "scenario": "default",
-  "insertionIndex": -1
+  "insertionIndex": -1,
+  "source": "/*---\ndescription: Should not test in strict mode (but allow strict mode to be enabled)\nflags: [raw]\n---*/\n'use strict';\nvar seemsStrict;\ntry {\n  x = 1;\n} catch (err) {\n  seemsStrict = err.constructor === ReferenceError;\n}\n\nif (!seemsStrict) {\n  throw new Error('Script erroneously not interpreted in strict mode.');\n}\n"
 }

--- a/test/collateral/valid-default/expected-metadata/test/rawStrict_default.json
+++ b/test/collateral/valid-default/expected-metadata/test/rawStrict_default.json
@@ -11,5 +11,5 @@
   "copyright": "",
   "scenario": "default",
   "insertionIndex": -1,
-  "raw": "/*---\ndescription: Should not test in strict mode (but allow strict mode to be enabled)\nflags: [raw]\n---*/\n'use strict';\nvar seemsStrict;\ntry {\n  x = 1;\n} catch (err) {\n  seemsStrict = err.constructor === ReferenceError;\n}\n\nif (!seemsStrict) {\n  throw new Error('Script erroneously not interpreted in strict mode.');\n}\n"
+  "source": null
 }

--- a/test/collateral/valid-default/expected-metadata/test/strict_strict_mode.json
+++ b/test/collateral/valid-default/expected-metadata/test/strict_strict_mode.json
@@ -17,5 +17,5 @@
   "copyright": "",
   "scenario": "strict mode",
   "insertionIndex": 904,
-  "raw": "/*---\ndescription: Should not test in sloppy mode\nflags: [onlyStrict]\nnegative:\n  phase: runtime\n  type: ReferenceError\n---*/\nx = 5;\n$ERROR('Not in strict mode');\n"
+  "source": null
 }

--- a/test/collateral/valid-default/expected-metadata/test/strict_strict_mode.json
+++ b/test/collateral/valid-default/expected-metadata/test/strict_strict_mode.json
@@ -16,5 +16,6 @@
   },
   "copyright": "",
   "scenario": "strict mode",
-  "insertionIndex": 904
+  "insertionIndex": 904,
+  "source": "/*---\ndescription: Should not test in sloppy mode\nflags: [onlyStrict]\nnegative:\n  phase: runtime\n  type: ReferenceError\n---*/\nx = 5;\n$ERROR('Not in strict mode');\n"
 }

--- a/test/collateral/valid-default/expected-metadata/test/strict_strict_mode.json
+++ b/test/collateral/valid-default/expected-metadata/test/strict_strict_mode.json
@@ -17,5 +17,5 @@
   "copyright": "",
   "scenario": "strict mode",
   "insertionIndex": 904,
-  "source": "/*---\ndescription: Should not test in sloppy mode\nflags: [onlyStrict]\nnegative:\n  phase: runtime\n  type: ReferenceError\n---*/\nx = 5;\n$ERROR('Not in strict mode');\n"
+  "raw": "/*---\ndescription: Should not test in sloppy mode\nflags: [onlyStrict]\nnegative:\n  phase: runtime\n  type: ReferenceError\n---*/\nx = 5;\n$ERROR('Not in strict mode');\n"
 }

--- a/test/collateral/valid-with-includes/expected-metadata/test/bothStrict_default.json
+++ b/test/collateral/valid-with-includes/expected-metadata/test/bothStrict_default.json
@@ -19,5 +19,6 @@
   },
   "copyright": "",
   "scenario": "default",
-  "insertionIndex": 921
+  "insertionIndex": 921,
+  "source": "/*---\ndescription: Should test in both modes\nfeatures: [var, try, if]\nnegative:\n  phase: runtime\n  type: ReferenceError\n---*/\nvar strict;\ntry { x = 1; strict = false;} catch(e) { strict = true }\n\nif(strict) {\n    y = 1;\n} else {\n    throw new ReferenceError();\n}\n"
 }

--- a/test/collateral/valid-with-includes/expected-metadata/test/bothStrict_default.json
+++ b/test/collateral/valid-with-includes/expected-metadata/test/bothStrict_default.json
@@ -20,5 +20,5 @@
   "copyright": "",
   "scenario": "default",
   "insertionIndex": 921,
-  "source": "/*---\ndescription: Should test in both modes\nfeatures: [var, try, if]\nnegative:\n  phase: runtime\n  type: ReferenceError\n---*/\nvar strict;\ntry { x = 1; strict = false;} catch(e) { strict = true }\n\nif(strict) {\n    y = 1;\n} else {\n    throw new ReferenceError();\n}\n"
+  "raw": "/*---\ndescription: Should test in both modes\nfeatures: [var, try, if]\nnegative:\n  phase: runtime\n  type: ReferenceError\n---*/\nvar strict;\ntry { x = 1; strict = false;} catch(e) { strict = true }\n\nif(strict) {\n    y = 1;\n} else {\n    throw new ReferenceError();\n}\n"
 }

--- a/test/collateral/valid-with-includes/expected-metadata/test/bothStrict_strict_mode.json
+++ b/test/collateral/valid-with-includes/expected-metadata/test/bothStrict_strict_mode.json
@@ -19,5 +19,6 @@
   },
   "copyright": "",
   "scenario": "strict mode",
-  "insertionIndex": 935
+  "insertionIndex": 935,
+  "source": "/*---\ndescription: Should test in both modes\nfeatures: [var, try, if]\nnegative:\n  phase: runtime\n  type: ReferenceError\n---*/\nvar strict;\ntry { x = 1; strict = false;} catch(e) { strict = true }\n\nif(strict) {\n    y = 1;\n} else {\n    throw new ReferenceError();\n}\n"
 }

--- a/test/collateral/valid-with-includes/expected-metadata/test/bothStrict_strict_mode.json
+++ b/test/collateral/valid-with-includes/expected-metadata/test/bothStrict_strict_mode.json
@@ -20,5 +20,5 @@
   "copyright": "",
   "scenario": "strict mode",
   "insertionIndex": 935,
-  "raw": "/*---\ndescription: Should test in both modes\nfeatures: [var, try, if]\nnegative:\n  phase: runtime\n  type: ReferenceError\n---*/\nvar strict;\ntry { x = 1; strict = false;} catch(e) { strict = true }\n\nif(strict) {\n    y = 1;\n} else {\n    throw new ReferenceError();\n}\n"
+  "source": null
 }

--- a/test/collateral/valid-with-includes/expected-metadata/test/bothStrict_strict_mode.json
+++ b/test/collateral/valid-with-includes/expected-metadata/test/bothStrict_strict_mode.json
@@ -20,5 +20,5 @@
   "copyright": "",
   "scenario": "strict mode",
   "insertionIndex": 935,
-  "source": "/*---\ndescription: Should test in both modes\nfeatures: [var, try, if]\nnegative:\n  phase: runtime\n  type: ReferenceError\n---*/\nvar strict;\ntry { x = 1; strict = false;} catch(e) { strict = true }\n\nif(strict) {\n    y = 1;\n} else {\n    throw new ReferenceError();\n}\n"
+  "raw": "/*---\ndescription: Should test in both modes\nfeatures: [var, try, if]\nnegative:\n  phase: runtime\n  type: ReferenceError\n---*/\nvar strict;\ntry { x = 1; strict = false;} catch(e) { strict = true }\n\nif(strict) {\n    y = 1;\n} else {\n    throw new ReferenceError();\n}\n"
 }

--- a/test/collateral/valid-with-paths/expected-metadata/test/async/asyncNegative_default.json
+++ b/test/collateral/valid-with-paths/expected-metadata/test/async/asyncNegative_default.json
@@ -16,5 +16,6 @@
   },
   "copyright": "",
   "scenario": "default",
-  "insertionIndex": 890
+  "insertionIndex": 890,
+  "source": "/*---\ndescription: Async negative test\nnegative:\n  phase: runtime\n  type: RangeError\nflags: [async]\n---*/\n\nsetTimeout(function() {\n  $DONE(new RangeError());\n}, 1000);\n"
 }

--- a/test/collateral/valid-with-paths/expected-metadata/test/async/asyncNegative_default.json
+++ b/test/collateral/valid-with-paths/expected-metadata/test/async/asyncNegative_default.json
@@ -17,5 +17,5 @@
   "copyright": "",
   "scenario": "default",
   "insertionIndex": 890,
-  "source": "/*---\ndescription: Async negative test\nnegative:\n  phase: runtime\n  type: RangeError\nflags: [async]\n---*/\n\nsetTimeout(function() {\n  $DONE(new RangeError());\n}, 1000);\n"
+  "raw": "/*---\ndescription: Async negative test\nnegative:\n  phase: runtime\n  type: RangeError\nflags: [async]\n---*/\n\nsetTimeout(function() {\n  $DONE(new RangeError());\n}, 1000);\n"
 }

--- a/test/collateral/valid-with-paths/expected-metadata/test/async/asyncNegative_default.json
+++ b/test/collateral/valid-with-paths/expected-metadata/test/async/asyncNegative_default.json
@@ -17,5 +17,5 @@
   "copyright": "",
   "scenario": "default",
   "insertionIndex": 890,
-  "raw": "/*---\ndescription: Async negative test\nnegative:\n  phase: runtime\n  type: RangeError\nflags: [async]\n---*/\n\nsetTimeout(function() {\n  $DONE(new RangeError());\n}, 1000);\n"
+  "source": null
 }

--- a/test/collateral/valid-with-paths/expected-metadata/test/async/asyncNegative_strict_mode.json
+++ b/test/collateral/valid-with-paths/expected-metadata/test/async/asyncNegative_strict_mode.json
@@ -16,5 +16,6 @@
   },
   "copyright": "",
   "scenario": "strict mode",
-  "insertionIndex": 904
+  "insertionIndex": 904,
+  "source": "/*---\ndescription: Async negative test\nnegative:\n  phase: runtime\n  type: RangeError\nflags: [async]\n---*/\n\nsetTimeout(function() {\n  $DONE(new RangeError());\n}, 1000);\n"
 }

--- a/test/collateral/valid-with-paths/expected-metadata/test/async/asyncNegative_strict_mode.json
+++ b/test/collateral/valid-with-paths/expected-metadata/test/async/asyncNegative_strict_mode.json
@@ -17,5 +17,5 @@
   "copyright": "",
   "scenario": "strict mode",
   "insertionIndex": 904,
-  "source": "/*---\ndescription: Async negative test\nnegative:\n  phase: runtime\n  type: RangeError\nflags: [async]\n---*/\n\nsetTimeout(function() {\n  $DONE(new RangeError());\n}, 1000);\n"
+  "raw": "/*---\ndescription: Async negative test\nnegative:\n  phase: runtime\n  type: RangeError\nflags: [async]\n---*/\n\nsetTimeout(function() {\n  $DONE(new RangeError());\n}, 1000);\n"
 }

--- a/test/collateral/valid-with-paths/expected-metadata/test/async/asyncNegative_strict_mode.json
+++ b/test/collateral/valid-with-paths/expected-metadata/test/async/asyncNegative_strict_mode.json
@@ -17,5 +17,5 @@
   "copyright": "",
   "scenario": "strict mode",
   "insertionIndex": 904,
-  "raw": "/*---\ndescription: Async negative test\nnegative:\n  phase: runtime\n  type: RangeError\nflags: [async]\n---*/\n\nsetTimeout(function() {\n  $DONE(new RangeError());\n}, 1000);\n"
+  "source": null
 }

--- a/test/collateral/valid-with-paths/expected-metadata/test/async/async_default.json
+++ b/test/collateral/valid-with-paths/expected-metadata/test/async/async_default.json
@@ -13,5 +13,5 @@
   "copyright": "",
   "scenario": "default",
   "insertionIndex": 890,
-  "source": "/*---\ndescription: Async test\nflags: [async]\n---*/\n\nvar p = new Promise(function(resolve) {\n  resolve();\n});\n\np.then($DONE, $DONE);\n"
+  "raw": "/*---\ndescription: Async test\nflags: [async]\n---*/\n\nvar p = new Promise(function(resolve) {\n  resolve();\n});\n\np.then($DONE, $DONE);\n"
 }

--- a/test/collateral/valid-with-paths/expected-metadata/test/async/async_default.json
+++ b/test/collateral/valid-with-paths/expected-metadata/test/async/async_default.json
@@ -13,5 +13,5 @@
   "copyright": "",
   "scenario": "default",
   "insertionIndex": 890,
-  "raw": "/*---\ndescription: Async test\nflags: [async]\n---*/\n\nvar p = new Promise(function(resolve) {\n  resolve();\n});\n\np.then($DONE, $DONE);\n"
+  "source": null
 }

--- a/test/collateral/valid-with-paths/expected-metadata/test/async/async_default.json
+++ b/test/collateral/valid-with-paths/expected-metadata/test/async/async_default.json
@@ -12,5 +12,6 @@
   },
   "copyright": "",
   "scenario": "default",
-  "insertionIndex": 890
+  "insertionIndex": 890,
+  "source": "/*---\ndescription: Async test\nflags: [async]\n---*/\n\nvar p = new Promise(function(resolve) {\n  resolve();\n});\n\np.then($DONE, $DONE);\n"
 }

--- a/test/collateral/valid-with-paths/expected-metadata/test/async/async_strict_mode.json
+++ b/test/collateral/valid-with-paths/expected-metadata/test/async/async_strict_mode.json
@@ -13,5 +13,5 @@
   "copyright": "",
   "scenario": "strict mode",
   "insertionIndex": 904,
-  "raw": "/*---\ndescription: Async test\nflags: [async]\n---*/\n\nvar p = new Promise(function(resolve) {\n  resolve();\n});\n\np.then($DONE, $DONE);\n"
+  "source": null
 }

--- a/test/collateral/valid-with-paths/expected-metadata/test/async/async_strict_mode.json
+++ b/test/collateral/valid-with-paths/expected-metadata/test/async/async_strict_mode.json
@@ -13,5 +13,5 @@
   "copyright": "",
   "scenario": "strict mode",
   "insertionIndex": 904,
-  "source": "/*---\ndescription: Async test\nflags: [async]\n---*/\n\nvar p = new Promise(function(resolve) {\n  resolve();\n});\n\np.then($DONE, $DONE);\n"
+  "raw": "/*---\ndescription: Async test\nflags: [async]\n---*/\n\nvar p = new Promise(function(resolve) {\n  resolve();\n});\n\np.then($DONE, $DONE);\n"
 }

--- a/test/collateral/valid-with-paths/expected-metadata/test/async/async_strict_mode.json
+++ b/test/collateral/valid-with-paths/expected-metadata/test/async/async_strict_mode.json
@@ -12,5 +12,6 @@
   },
   "copyright": "",
   "scenario": "strict mode",
-  "insertionIndex": 904
+  "insertionIndex": 904,
+  "source": "/*---\ndescription: Async test\nflags: [async]\n---*/\n\nvar p = new Promise(function(resolve) {\n  resolve();\n});\n\np.then($DONE, $DONE);\n"
 }

--- a/test/collateral/valid-with-paths/expected-metadata/test/bothStrict_default.json
+++ b/test/collateral/valid-with-paths/expected-metadata/test/bothStrict_default.json
@@ -20,5 +20,5 @@
   "copyright": "",
   "scenario": "default",
   "insertionIndex": 890,
-  "raw": "/*---\ndescription: Should test in both modes\nfeatures: [var, try, if]\nnegative:\n  phase: runtime\n  type: ReferenceError\n---*/\nvar strict;\ntry { x = 1; strict = false;} catch(e) { strict = true }\n\nif(strict) {\n    y = 1;\n} else {\n    throw new ReferenceError();\n}\n"
+  "source": null
 }

--- a/test/collateral/valid-with-paths/expected-metadata/test/bothStrict_default.json
+++ b/test/collateral/valid-with-paths/expected-metadata/test/bothStrict_default.json
@@ -20,5 +20,5 @@
   "copyright": "",
   "scenario": "default",
   "insertionIndex": 890,
-  "source": "/*---\ndescription: Should test in both modes\nfeatures: [var, try, if]\nnegative:\n  phase: runtime\n  type: ReferenceError\n---*/\nvar strict;\ntry { x = 1; strict = false;} catch(e) { strict = true }\n\nif(strict) {\n    y = 1;\n} else {\n    throw new ReferenceError();\n}\n"
+  "raw": "/*---\ndescription: Should test in both modes\nfeatures: [var, try, if]\nnegative:\n  phase: runtime\n  type: ReferenceError\n---*/\nvar strict;\ntry { x = 1; strict = false;} catch(e) { strict = true }\n\nif(strict) {\n    y = 1;\n} else {\n    throw new ReferenceError();\n}\n"
 }

--- a/test/collateral/valid-with-paths/expected-metadata/test/bothStrict_default.json
+++ b/test/collateral/valid-with-paths/expected-metadata/test/bothStrict_default.json
@@ -19,5 +19,6 @@
   },
   "copyright": "",
   "scenario": "default",
-  "insertionIndex": 890
+  "insertionIndex": 890,
+  "source": "/*---\ndescription: Should test in both modes\nfeatures: [var, try, if]\nnegative:\n  phase: runtime\n  type: ReferenceError\n---*/\nvar strict;\ntry { x = 1; strict = false;} catch(e) { strict = true }\n\nif(strict) {\n    y = 1;\n} else {\n    throw new ReferenceError();\n}\n"
 }

--- a/test/collateral/valid-with-paths/expected-metadata/test/bothStrict_strict_mode.json
+++ b/test/collateral/valid-with-paths/expected-metadata/test/bothStrict_strict_mode.json
@@ -20,5 +20,5 @@
   "copyright": "",
   "scenario": "strict mode",
   "insertionIndex": 904,
-  "source": "/*---\ndescription: Should test in both modes\nfeatures: [var, try, if]\nnegative:\n  phase: runtime\n  type: ReferenceError\n---*/\nvar strict;\ntry { x = 1; strict = false;} catch(e) { strict = true }\n\nif(strict) {\n    y = 1;\n} else {\n    throw new ReferenceError();\n}\n"
+  "raw": "/*---\ndescription: Should test in both modes\nfeatures: [var, try, if]\nnegative:\n  phase: runtime\n  type: ReferenceError\n---*/\nvar strict;\ntry { x = 1; strict = false;} catch(e) { strict = true }\n\nif(strict) {\n    y = 1;\n} else {\n    throw new ReferenceError();\n}\n"
 }

--- a/test/collateral/valid-with-paths/expected-metadata/test/bothStrict_strict_mode.json
+++ b/test/collateral/valid-with-paths/expected-metadata/test/bothStrict_strict_mode.json
@@ -19,5 +19,6 @@
   },
   "copyright": "",
   "scenario": "strict mode",
-  "insertionIndex": 904
+  "insertionIndex": 904,
+  "source": "/*---\ndescription: Should test in both modes\nfeatures: [var, try, if]\nnegative:\n  phase: runtime\n  type: ReferenceError\n---*/\nvar strict;\ntry { x = 1; strict = false;} catch(e) { strict = true }\n\nif(strict) {\n    y = 1;\n} else {\n    throw new ReferenceError();\n}\n"
 }

--- a/test/collateral/valid-with-paths/expected-metadata/test/bothStrict_strict_mode.json
+++ b/test/collateral/valid-with-paths/expected-metadata/test/bothStrict_strict_mode.json
@@ -20,5 +20,5 @@
   "copyright": "",
   "scenario": "strict mode",
   "insertionIndex": 904,
-  "raw": "/*---\ndescription: Should test in both modes\nfeatures: [var, try, if]\nnegative:\n  phase: runtime\n  type: ReferenceError\n---*/\nvar strict;\ntry { x = 1; strict = false;} catch(e) { strict = true }\n\nif(strict) {\n    y = 1;\n} else {\n    throw new ReferenceError();\n}\n"
+  "source": null
 }

--- a/test/collateral/valid-with-paths/expected-metadata/test/strict/no/noStrict_default.json
+++ b/test/collateral/valid-with-paths/expected-metadata/test/strict/no/noStrict_default.json
@@ -13,5 +13,5 @@
   "copyright": "",
   "scenario": "default",
   "insertionIndex": 890,
-  "raw": "/*---\ndescription: Should not test in strict mode\nflags: [noStrict]\n---*/\nx = 5;\n"
+  "source": null
 }

--- a/test/collateral/valid-with-paths/expected-metadata/test/strict/no/noStrict_default.json
+++ b/test/collateral/valid-with-paths/expected-metadata/test/strict/no/noStrict_default.json
@@ -12,5 +12,6 @@
   },
   "copyright": "",
   "scenario": "default",
-  "insertionIndex": 890
+  "insertionIndex": 890,
+  "source": "/*---\ndescription: Should not test in strict mode\nflags: [noStrict]\n---*/\nx = 5;\n"
 }

--- a/test/collateral/valid-with-paths/expected-metadata/test/strict/no/noStrict_default.json
+++ b/test/collateral/valid-with-paths/expected-metadata/test/strict/no/noStrict_default.json
@@ -13,5 +13,5 @@
   "copyright": "",
   "scenario": "default",
   "insertionIndex": 890,
-  "source": "/*---\ndescription: Should not test in strict mode\nflags: [noStrict]\n---*/\nx = 5;\n"
+  "raw": "/*---\ndescription: Should not test in strict mode\nflags: [noStrict]\n---*/\nx = 5;\n"
 }

--- a/test/collateral/valid-with-paths/expected-metadata/test/strict/no/rawNoStrict_default.json
+++ b/test/collateral/valid-with-paths/expected-metadata/test/strict/no/rawNoStrict_default.json
@@ -10,5 +10,6 @@
   },
   "copyright": "",
   "scenario": "default",
-  "insertionIndex": -1
+  "insertionIndex": -1,
+  "source": "/*---\ndescription: Should not test in strict mode\nflags: [raw]\n---*/\nvar seemsStrict;\ntry {\n  x = 1;\n} catch (err) {\n  seemsStrict = err.constructor === ReferenceError;\n}\n\nif (seemsStrict) {\n  throw new Error('Script erroneously interpreted in strict mode.');\n}\n"
 }

--- a/test/collateral/valid-with-paths/expected-metadata/test/strict/no/rawNoStrict_default.json
+++ b/test/collateral/valid-with-paths/expected-metadata/test/strict/no/rawNoStrict_default.json
@@ -11,5 +11,5 @@
   "copyright": "",
   "scenario": "default",
   "insertionIndex": -1,
-  "source": "/*---\ndescription: Should not test in strict mode\nflags: [raw]\n---*/\nvar seemsStrict;\ntry {\n  x = 1;\n} catch (err) {\n  seemsStrict = err.constructor === ReferenceError;\n}\n\nif (seemsStrict) {\n  throw new Error('Script erroneously interpreted in strict mode.');\n}\n"
+  "raw": "/*---\ndescription: Should not test in strict mode\nflags: [raw]\n---*/\nvar seemsStrict;\ntry {\n  x = 1;\n} catch (err) {\n  seemsStrict = err.constructor === ReferenceError;\n}\n\nif (seemsStrict) {\n  throw new Error('Script erroneously interpreted in strict mode.');\n}\n"
 }

--- a/test/collateral/valid-with-paths/expected-metadata/test/strict/no/rawNoStrict_default.json
+++ b/test/collateral/valid-with-paths/expected-metadata/test/strict/no/rawNoStrict_default.json
@@ -11,5 +11,5 @@
   "copyright": "",
   "scenario": "default",
   "insertionIndex": -1,
-  "raw": "/*---\ndescription: Should not test in strict mode\nflags: [raw]\n---*/\nvar seemsStrict;\ntry {\n  x = 1;\n} catch (err) {\n  seemsStrict = err.constructor === ReferenceError;\n}\n\nif (seemsStrict) {\n  throw new Error('Script erroneously interpreted in strict mode.');\n}\n"
+  "source": null
 }

--- a/test/collateral/valid-with-source/expected-content/test/bothStrict_default.js
+++ b/test/collateral/valid-with-source/expected-content/test/bothStrict_default.js
@@ -1,0 +1,63 @@
+function Test262Error(message) {
+    if (message) this.message = message;
+}
+
+Test262Error.prototype.name = "Test262Error";
+
+Test262Error.prototype.toString = function () {
+    return "Test262Error: " + this.message;
+};
+
+function $ERROR(err) {
+  if(typeof err === "object" && err !== null && "name" in err) {
+      throw err;
+  } else {
+    throw new Test262Error(err);
+  }
+}
+
+function $DONE(err) {
+  if (err) {
+    if(typeof err === "object" && err !== null && "name" in err) {
+      print('test262/error ' + err.name + ': ' + err.message);
+    } else {
+      print('test262/error Test262Error: ' + err);
+    }
+  }
+  print('test262/done');
+  $262.destroy();
+}
+
+function $LOG(str) {
+  print(str);
+}
+
+
+// This is assert.js
+
+'It has some contents';
+
+/* that
+ *
+ * should
+
+ * not
+ */
+
+`be ${ "modified" }`;
+
+var including, trailing;
+whitespace: ;                    
+
+void "end of assert.js";
+
+var strict;
+try { x = 1; strict = false;} catch(e) { strict = true }
+
+if(strict) {
+    y = 1;
+} else {
+    throw new ReferenceError();
+}
+
+;$DONE();

--- a/test/collateral/valid-with-source/expected-content/test/bothStrict_strict_mode.js
+++ b/test/collateral/valid-with-source/expected-content/test/bothStrict_strict_mode.js
@@ -1,0 +1,64 @@
+"use strict";
+function Test262Error(message) {
+    if (message) this.message = message;
+}
+
+Test262Error.prototype.name = "Test262Error";
+
+Test262Error.prototype.toString = function () {
+    return "Test262Error: " + this.message;
+};
+
+function $ERROR(err) {
+  if(typeof err === "object" && err !== null && "name" in err) {
+      throw err;
+  } else {
+    throw new Test262Error(err);
+  }
+}
+
+function $DONE(err) {
+  if (err) {
+    if(typeof err === "object" && err !== null && "name" in err) {
+      print('test262/error ' + err.name + ': ' + err.message);
+    } else {
+      print('test262/error Test262Error: ' + err);
+    }
+  }
+  print('test262/done');
+  $262.destroy();
+}
+
+function $LOG(str) {
+  print(str);
+}
+
+
+// This is assert.js
+
+'It has some contents';
+
+/* that
+ *
+ * should
+
+ * not
+ */
+
+`be ${ "modified" }`;
+
+var including, trailing;
+whitespace: ;                    
+
+void "end of assert.js";
+
+var strict;
+try { x = 1; strict = false;} catch(e) { strict = true }
+
+if(strict) {
+    y = 1;
+} else {
+    throw new ReferenceError();
+}
+
+;$DONE();

--- a/test/collateral/valid-with-source/expected-metadata/test/bothStrict_default.json
+++ b/test/collateral/valid-with-source/expected-metadata/test/bothStrict_default.json
@@ -19,6 +19,6 @@
   },
   "copyright": "",
   "scenario": "default",
-  "insertionIndex": 921,
-  "source": null
+  "insertionIndex": 890,
+  "source": "/*---\ndescription: Should test in both modes\nfeatures: [var, try, if]\nnegative:\n  phase: runtime\n  type: ReferenceError\n---*/\nvar strict;\ntry { x = 1; strict = false;} catch(e) { strict = true }\n\nif(strict) {\n    y = 1;\n} else {\n    throw new ReferenceError();\n}\n"
 }

--- a/test/collateral/valid-with-source/expected-metadata/test/bothStrict_strict_mode.json
+++ b/test/collateral/valid-with-source/expected-metadata/test/bothStrict_strict_mode.json
@@ -20,5 +20,5 @@
   "copyright": "",
   "scenario": "strict mode",
   "insertionIndex": 904,
-  "source": null
+  "source": "/*---\ndescription: Should test in both modes\nfeatures: [var, try, if]\nnegative:\n  phase: runtime\n  type: ReferenceError\n---*/\nvar strict;\ntry { x = 1; strict = false;} catch(e) { strict = true }\n\nif(strict) {\n    y = 1;\n} else {\n    throw new ReferenceError();\n}\n"
 }

--- a/test/collateral/valid-with-source/fake-test262/harness/assert.js
+++ b/test/collateral/valid-with-source/fake-test262/harness/assert.js
@@ -1,0 +1,17 @@
+// This is assert.js
+
+'It has some contents';
+
+/* that
+ *
+ * should
+
+ * not
+ */
+
+`be ${ "modified" }`;
+
+var including, trailing;
+whitespace: ;                    
+
+void "end of assert.js";

--- a/test/collateral/valid-with-source/fake-test262/test/bothStrict.js
+++ b/test/collateral/valid-with-source/fake-test262/test/bothStrict.js
@@ -1,0 +1,15 @@
+/*---
+description: Should test in both modes
+features: [var, try, if]
+negative:
+  phase: runtime
+  type: ReferenceError
+---*/
+var strict;
+try { x = 1; strict = false;} catch(e) { strict = true }
+
+if(strict) {
+    y = 1;
+} else {
+    throw new ReferenceError();
+}

--- a/test/test.js
+++ b/test/test.js
@@ -132,6 +132,26 @@ tape('valid source directory (with custom includes)', t => {
   });
 });
 
+tape('withSource', t => {
+  const fixtureDir = path.join(__dirname, 'collateral', 'valid-with-source');
+  const stream = new TestStream(path.join(fixtureDir, 'fake-test262'), {
+    withSource: true
+  });
+  const ids = [];
+
+  stream.on('data', makeDataHandler(t, ids, fixtureDir));
+
+  stream.on('error', (error) => {
+    t.ok(error);
+    t.end(error);
+  });
+
+  stream.on('end', () => {
+    t.equal(ids.length, 2, 'Reports every available test');
+    t.end();
+  });
+});
+
 tape('missing `assert.js`', t => {
   const stream = new TestStream(path.join(__dirname, 'collateral', 'invalid-missing-harness'));
 


### PR DESCRIPTION
This enables optimizations such as: 

```js
const stream = new TestStream(test262Dir, {
  includesDir,
  paths,
});

stream.on("data", test => {
  fs.readFile(path.join(test262Dir, test.file), "utf8", (error, contents) => {
    let ast = recast.parse(contents);
    // ...do stuff with ast, save new test source somewhere...
  });
});
```

To:  

```js
const stream = new TestStream(test262Dir, {
  includesDir,
  paths,
});

stream.on("data", test => {
  let ast = recast.parse(test.raw);
  // ...do stuff with ast, save new test source somewhere...
});
```

