### PR TITLE
Configuration option: skipScenarios

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -22,7 +22,7 @@ module.exports = function (filePath, options, done) {
       .replace(endFrontmatterPattern, '$&' + test262StreamMarker);
 
     const descriptor = { file: filePath, contents };
-    const tests = createScenarios(compile(descriptor, options));
+    const tests = settleScenarios(compile(descriptor, options), options);
 
     tests.forEach((test) => {
       test.insertionIndex = test.attrs.flags.raw ?
@@ -41,3 +41,11 @@ module.exports = function (filePath, options, done) {
     done(null, tests);
   });
 };
+
+function settleScenarios(compiled, options) {
+  let scenarios = createScenarios(compiled);
+  if (options.skipScenarios) {
+    return scenarios.slice(0, 1);
+  }
+  return scenarios;
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -42,6 +42,10 @@ const fixturePattern = /_FIXTURE\.[jJ][sS]$/;
  *                                         "includes" files (defaults to the
  *                                         appropriate subdirectory of the
  *                                         provided `test262Dir`
+ * @param {boolean} [options.skipScenarios] - Defaults to `false`. When set to
+ *                                            `true`, only the default scenario
+ *                                            is returned, instead of both the
+ *                                            default and strict mode scenarios
  * @param {Array<string>} [options.paths] - file system paths refining the set
  *                                          of tests that should be produced;
  *                                          only tests whose source file
@@ -69,7 +73,8 @@ module.exports = class TestStream extends Readable {
       .map(relativePath => path.join(test262Dir, relativePath));
     this[compileOpts] = {
       test262Dir,
-      includesDir: options.includesDir
+      includesDir: options.includesDir,
+      skipScenarios: options.skipScenarios ? true : false,
     };
     this[fileStream] = null;
     this[pendingOps] = 0;

--- a/test/collateral/valid-skip-scenarios/expected-content/test/skipScenarios_default.js
+++ b/test/collateral/valid-skip-scenarios/expected-content/test/skipScenarios_default.js
@@ -1,0 +1,63 @@
+function Test262Error(message) {
+    if (message) this.message = message;
+}
+
+Test262Error.prototype.name = "Test262Error";
+
+Test262Error.prototype.toString = function () {
+    return "Test262Error: " + this.message;
+};
+
+function $ERROR(err) {
+  if(typeof err === "object" && err !== null && "name" in err) {
+      throw err;
+  } else {
+    throw new Test262Error(err);
+  }
+}
+
+function $DONE(err) {
+  if (err) {
+    if(typeof err === "object" && err !== null && "name" in err) {
+      print('test262/error ' + err.name + ': ' + err.message);
+    } else {
+      print('test262/error Test262Error: ' + err);
+    }
+  }
+  print('test262/done');
+  $262.destroy();
+}
+
+function $LOG(str) {
+  print(str);
+}
+
+
+// This is assert.js
+
+'It has some contents';
+
+/* that
+ *
+ * should
+
+ * not
+ */
+
+`be ${ "modified" }`;
+
+var including, trailing;
+whitespace: ;                    
+
+void "end of assert.js";
+
+var strict;
+try { x = 1; strict = false;} catch(e) { strict = true }
+
+if(strict) {
+    y = 1;
+} else {
+    throw new ReferenceError();
+}
+
+;$DONE();

--- a/test/collateral/valid-skip-scenarios/expected-metadata/test/skipScenarios_default.json
+++ b/test/collateral/valid-skip-scenarios/expected-metadata/test/skipScenarios_default.json
@@ -1,0 +1,23 @@
+{
+  "file": "test/skipScenarios.js",
+  "contents": "(The value of this property is over-sized, so it is validated independently.)",
+  "attrs": {
+    "description": "Should only produce one test object, with the default scenario",
+    "features": [
+      "var",
+      "try",
+      "if"
+    ],
+    "negative": {
+      "phase": "runtime",
+      "type": "ReferenceError"
+    },
+    "flags": {},
+    "includes": [
+      "assert.js"
+    ]
+  },
+  "copyright": "",
+  "scenario": "default",
+  "insertionIndex": 890
+}

--- a/test/collateral/valid-skip-scenarios/fake-test262/harness/assert.js
+++ b/test/collateral/valid-skip-scenarios/fake-test262/harness/assert.js
@@ -1,0 +1,17 @@
+// This is assert.js
+
+'It has some contents';
+
+/* that
+ *
+ * should
+
+ * not
+ */
+
+`be ${ "modified" }`;
+
+var including, trailing;
+whitespace: ;                    
+
+void "end of assert.js";

--- a/test/collateral/valid-skip-scenarios/fake-test262/test/skipScenarios.js
+++ b/test/collateral/valid-skip-scenarios/fake-test262/test/skipScenarios.js
@@ -1,0 +1,15 @@
+/*---
+description: Should only produce one test object, with the default scenario
+features: [var, try, if]
+negative:
+  phase: runtime
+  type: ReferenceError
+---*/
+var strict;
+try { x = 1; strict = false;} catch(e) { strict = true }
+
+if(strict) {
+    y = 1;
+} else {
+    throw new ReferenceError();
+}

--- a/test/test.js
+++ b/test/test.js
@@ -41,7 +41,7 @@ function makeDataHandler(t, ids, fixtureDir) {
       return;
     }
 
-    // `RegExp.prototype.test` acceptes `undefined`, so an explicit type
+    // `RegExp.prototype.test` accepts `undefined`, so an explicit type
     // check is necessary.
     t.equal(typeof test.scenario, 'string', '`scenario` property is a string value');
     t.ok(scenarios.test(test.scenario), '`scenario` property is a valid value');
@@ -128,6 +128,24 @@ tape('valid source directory (with custom includes)', t => {
 
   stream.on('end', () => {
     t.equal(ids.length, 2, 'Reports every available test');
+    t.end();
+  });
+});
+
+tape('skipScenarios', t => {
+  const fixtureDir = path.join(__dirname, 'collateral', 'valid-skip-scenarios');
+  const stream = new TestStream(path.join(fixtureDir, 'fake-test262'), { skipScenarios: true });
+  const ids = [];
+
+  stream.on('data', makeDataHandler(t, ids, fixtureDir));
+
+  stream.on('error', (error) => {
+    t.ok(error);
+    t.end(error);
+  });
+
+  stream.on('end', () => {
+    t.equal(ids.length, 1, 'Reports every available test');
     t.end();
   });
 });


### PR DESCRIPTION
Defaults to "false". When set to "true", only the default scenario is returned, instead of both the default and the strict mode scenarious.

