### PR TITLE
Simplify internals

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -5,9 +5,6 @@ const compile = require('./compiler');
 
 const createScenarios = require('./create-scenarios');
 
-const endFrontmatterPattern = /---\*\/\r?\n/g;
-const test262StreamMarker = '/* Inserted by Test262Stream */';
-
 module.exports = function (filePath, options, done) {
   fs.readFile(filePath, 'utf-8', (err, contents) => {
     if (err) {
@@ -15,28 +12,11 @@ module.exports = function (filePath, options, done) {
       return;
     }
 
-    // The "compilation" process removes the tests' frontmatter, so a temporary
-    // marker must be introduced so the insertion index can be identified
-    // following compilation.
-    contents = contents
-      .replace(endFrontmatterPattern, '$&' + test262StreamMarker);
-
-    const descriptor = { file: filePath, contents };
+    const descriptor = {
+      file: path.relative(options.test262Dir, filePath),
+      contents
+    };
     const tests = createScenarios(compile(descriptor, options));
-
-    tests.forEach((test) => {
-      test.insertionIndex = test.attrs.flags.raw ?
-        -1 : test.contents.indexOf(test262StreamMarker);
-      test.contents = test.contents.replace(test262StreamMarker, '');
-
-      test.file = path.relative(options.test262Dir, test.file);
-
-      // The following properties are provided by the `test262-parser` module,
-      // they are inconsistent and possibly confusing.
-      delete test.isATest;
-      delete test.async;
-      delete test.strictMode;
-    });
 
     done(null, tests);
   });

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -16,7 +16,7 @@ module.exports = function compile(test, options) {
   test = parseFile(test);
 
   // The following properties are defined by the `test262-parser` module. They
-  // are removed here because they are inconsistent could therefor cause
+  // are removed here because they are inconsistent could therefore cause
   // confusion.
   delete test.isATest;
   delete test.async;

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -15,7 +15,17 @@ module.exports = function compile(test, options) {
 
   test = parseFile(test);
 
+  // The following properties are defined by the `test262-parser` module. They
+  // are removed here because they are inconsistent could therefor cause
+  // confusion.
+  delete test.isATest;
+  delete test.async;
+  delete test.strictMode;
+
+  test.scenario = null;
+
   if (test.attrs.flags.raw) {
+    test.insertionIndex = -1;
     return test;
   }
 
@@ -44,6 +54,7 @@ module.exports = function compile(test, options) {
   }
 
   test.contents = preludeContents + test.contents;
+  test.insertionIndex = preludeContents.length + 1;
 
   return test;
 };

--- a/lib/create-scenarios.js
+++ b/lib/create-scenarios.js
@@ -1,4 +1,6 @@
 'use strict';
+const usd = '"use strict";\n';
+const usdLength = usd.length;
 
 module.exports = function scenariosForTest(test) {
   // The "compilation" logic has been inherited from the `test262-compiler`
@@ -15,7 +17,8 @@ module.exports = function scenariosForTest(test) {
     const copy = Object.assign({}, test);
     copy.attrs = Object.assign({}, test.attrs);
     copy.attrs.description += ' (Strict Mode)';
-    copy.contents = `"use strict";\n${copy.contents}`;
+    copy.contents = usd + copy.contents;
+    copy.insertionIndex += usdLength;
     copy.scenario = 'strict mode';
     // test both modes
     return [test, copy];


### PR DESCRIPTION
Previously, test "compilation" was performed by an external module. This
project included code to manipulate the output of that module in a
sub-optimal way. Because a recent commit incorporated the external
module into this project directly, the sub-optimal code is no longer
necessary.

Refactor the internals to produce the same output in a more readable and
efficient way.