### PR TITLE
Detect completion when traversal ends w/non-tests

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -146,6 +146,12 @@ module.exports = class TestStream extends Readable {
         this.traverse();
       } else {
         this[fileStreamDone] = true;
+
+        // If the final file visited is not a test and compilation for all
+        // other tests has completed, the stream should signal completion.
+        if (this[pendingOps] === 0) {
+          this.push(null);
+        }
       }
     });
   }

--- a/test/collateral/valid-extra-files/expected-content/test/bothStrict_default.js
+++ b/test/collateral/valid-extra-files/expected-content/test/bothStrict_default.js
@@ -1,0 +1,42 @@
+// This is assert.js
+
+'It has some contents';
+
+/* that
+ *
+ * should
+
+ * not
+ */
+
+`be ${ "modified" }`;
+
+var including, trailing;
+whitespace: ;                    
+
+void "end of assert.js";
+
+function Test262Error(message) {
+  this.message = message || "";
+}
+
+Test262Error.prototype.toString = function () {
+  return "Test262Error: " + this.message;
+};
+
+var $ERROR;
+$ERROR = function $ERROR(message) {
+  throw new Test262Error(message);
+};
+
+
+var strict;
+try { x = 1; strict = false;} catch(e) { strict = true }
+
+if(strict) {
+    y = 1;
+} else {
+    throw new ReferenceError();
+}
+
+;$DONE();

--- a/test/collateral/valid-extra-files/expected-content/test/bothStrict_strict_mode.js
+++ b/test/collateral/valid-extra-files/expected-content/test/bothStrict_strict_mode.js
@@ -1,0 +1,43 @@
+"use strict";
+// This is assert.js
+
+'It has some contents';
+
+/* that
+ *
+ * should
+
+ * not
+ */
+
+`be ${ "modified" }`;
+
+var including, trailing;
+whitespace: ;                    
+
+void "end of assert.js";
+
+function Test262Error(message) {
+  this.message = message || "";
+}
+
+Test262Error.prototype.toString = function () {
+  return "Test262Error: " + this.message;
+};
+
+var $ERROR;
+$ERROR = function $ERROR(message) {
+  throw new Test262Error(message);
+};
+
+
+var strict;
+try { x = 1; strict = false;} catch(e) { strict = true }
+
+if(strict) {
+    y = 1;
+} else {
+    throw new ReferenceError();
+}
+
+;$DONE();

--- a/test/collateral/valid-extra-files/expected-metadata/test/bothStrict_default.json
+++ b/test/collateral/valid-extra-files/expected-metadata/test/bothStrict_default.json
@@ -1,0 +1,24 @@
+{
+  "file": "test/bothStrict.js",
+  "contents": "(The value of this property is over-sized, so it is validated independently.)",
+  "attrs": {
+    "description": "Should test in both modes",
+    "features": [
+      "var",
+      "try",
+      "if"
+    ],
+    "negative": {
+      "phase": "runtime",
+      "type": "ReferenceError"
+    },
+    "flags": {},
+    "includes": [
+      "assert.js",
+      "sta.js"
+    ]
+  },
+  "copyright": "",
+  "scenario": "default",
+  "insertionIndex": 440
+}

--- a/test/collateral/valid-extra-files/expected-metadata/test/bothStrict_strict_mode.json
+++ b/test/collateral/valid-extra-files/expected-metadata/test/bothStrict_strict_mode.json
@@ -1,0 +1,24 @@
+{
+  "file": "test/bothStrict.js",
+  "contents": "(The value of this property is over-sized, so it is validated independently.)",
+  "attrs": {
+    "description": "Should test in both modes (Strict Mode)",
+    "features": [
+      "var",
+      "try",
+      "if"
+    ],
+    "negative": {
+      "phase": "runtime",
+      "type": "ReferenceError"
+    },
+    "flags": {},
+    "includes": [
+      "assert.js",
+      "sta.js"
+    ]
+  },
+  "copyright": "",
+  "scenario": "strict mode",
+  "insertionIndex": 454
+}

--- a/test/collateral/valid-extra-files/fake-test262/harness/assert.js
+++ b/test/collateral/valid-extra-files/fake-test262/harness/assert.js
@@ -1,0 +1,17 @@
+// This is assert.js
+
+'It has some contents';
+
+/* that
+ *
+ * should
+
+ * not
+ */
+
+`be ${ "modified" }`;
+
+var including, trailing;
+whitespace: ;                    
+
+void "end of assert.js";

--- a/test/collateral/valid-extra-files/fake-test262/harness/doneprintHandle.js
+++ b/test/collateral/valid-extra-files/fake-test262/harness/doneprintHandle.js
@@ -1,0 +1,6 @@
+function $DONE(){
+  if(!arguments[0])
+    print('Test262:AsyncTestComplete');
+  else
+    print('Error: ' + arguments[0]);
+}

--- a/test/collateral/valid-extra-files/fake-test262/harness/sta.js
+++ b/test/collateral/valid-extra-files/fake-test262/harness/sta.js
@@ -1,0 +1,12 @@
+function Test262Error(message) {
+  this.message = message || "";
+}
+
+Test262Error.prototype.toString = function () {
+  return "Test262Error: " + this.message;
+};
+
+var $ERROR;
+$ERROR = function $ERROR(message) {
+  throw new Test262Error(message);
+};

--- a/test/collateral/valid-extra-files/fake-test262/test/bothStrict.js
+++ b/test/collateral/valid-extra-files/fake-test262/test/bothStrict.js
@@ -1,0 +1,15 @@
+/*---
+description: Should test in both modes
+features: [var, try, if]
+negative:
+  phase: runtime
+  type: ReferenceError
+---*/
+var strict;
+try { x = 1; strict = false;} catch(e) { strict = true }
+
+if(strict) {
+    y = 1;
+} else {
+    throw new ReferenceError();
+}

--- a/test/collateral/valid-extra-files/fake-test262/test/zzz-0_FIXTURE.js
+++ b/test/collateral/valid-extra-files/fake-test262/test/zzz-0_FIXTURE.js
@@ -1,0 +1,2 @@
+// This non-test file is present only to ensure that traversal continues beyond
+// the moment that all tests have been compiled.

--- a/test/collateral/valid-extra-files/fake-test262/test/zzz-1_FIXTURE.js
+++ b/test/collateral/valid-extra-files/fake-test262/test/zzz-1_FIXTURE.js
@@ -1,0 +1,2 @@
+// This non-test file is present only to ensure that traversal continues beyond
+// the moment that all tests have been compiled.

--- a/test/collateral/valid-extra-files/fake-test262/test/zzz-2_FIXTURE.js
+++ b/test/collateral/valid-extra-files/fake-test262/test/zzz-2_FIXTURE.js
@@ -1,0 +1,2 @@
+// This non-test file is present only to ensure that traversal continues beyond
+// the moment that all tests have been compiled.

--- a/test/collateral/valid-extra-files/fake-test262/test/zzz-3_FIXTURE.js
+++ b/test/collateral/valid-extra-files/fake-test262/test/zzz-3_FIXTURE.js
@@ -1,0 +1,2 @@
+// This non-test file is present only to ensure that traversal continues beyond
+// the moment that all tests have been compiled.

--- a/test/collateral/valid-extra-files/fake-test262/test/zzz-4_FIXTURE.js
+++ b/test/collateral/valid-extra-files/fake-test262/test/zzz-4_FIXTURE.js
@@ -1,0 +1,2 @@
+// This non-test file is present only to ensure that traversal continues beyond
+// the moment that all tests have been compiled.

--- a/test/collateral/valid-extra-files/fake-test262/test/zzz-5_FIXTURE.js
+++ b/test/collateral/valid-extra-files/fake-test262/test/zzz-5_FIXTURE.js
@@ -1,0 +1,2 @@
+// This non-test file is present only to ensure that traversal continues beyond
+// the moment that all tests have been compiled.

--- a/test/collateral/valid-extra-files/fake-test262/test/zzz-6_FIXTURE.js
+++ b/test/collateral/valid-extra-files/fake-test262/test/zzz-6_FIXTURE.js
@@ -1,0 +1,2 @@
+// This non-test file is present only to ensure that traversal continues beyond
+// the moment that all tests have been compiled.

--- a/test/collateral/valid-extra-files/fake-test262/test/zzz-7_FIXTURE.js
+++ b/test/collateral/valid-extra-files/fake-test262/test/zzz-7_FIXTURE.js
@@ -1,0 +1,2 @@
+// This non-test file is present only to ensure that traversal continues beyond
+// the moment that all tests have been compiled.

--- a/test/collateral/valid-extra-files/fake-test262/test/zzz-8_FIXTURE.js
+++ b/test/collateral/valid-extra-files/fake-test262/test/zzz-8_FIXTURE.js
@@ -1,0 +1,2 @@
+// This non-test file is present only to ensure that traversal continues beyond
+// the moment that all tests have been compiled.

--- a/test/collateral/valid-extra-files/fake-test262/test/zzz-9_FIXTURE.js
+++ b/test/collateral/valid-extra-files/fake-test262/test/zzz-9_FIXTURE.js
@@ -1,0 +1,2 @@
+// This non-test file is present only to ensure that traversal continues beyond
+// the moment that all tests have been compiled.

--- a/test/test.js
+++ b/test/test.js
@@ -261,3 +261,22 @@ tape('omit runtime', t => {
     t.end();
   });
 });
+
+tape('completion detection when final files visited are not tests', t => {
+  const fixtureDir = path.join(__dirname, 'collateral', 'valid-extra-files');
+  const stream = new TestStream(path.join(fixtureDir, 'fake-test262'));
+  const ids = [];
+
+  global.mike = true;
+  stream.on('data', makeDataHandler(t, ids, fixtureDir));
+
+  stream.on('error', (error) => {
+    t.ok(error);
+    t.end(error);
+  });
+
+  stream.on('end', () => {
+    t.equal(ids.length, 2, 'Reports every available test');
+    t.end();
+  });
+});


### PR DESCRIPTION
Ensure that the stream's `done` event is properly emitted in cases where
file traversal continues after all available tests have been emitted.

@rwaldron Mind taking a look?