### PR TITLE
Remove undocumented modification

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -29,10 +29,6 @@ module.exports = function compile(test, options) {
     return test;
   }
 
-  if (test.contents.indexOf('$DONE') === -1) {
-    test.contents += '\n;$DONE();';
-  }
-
   const helpers = test.attrs.includes;
   helpers.push('assert.js');
   helpers.push('sta.js');

--- a/test/collateral/valid-default/expected-content/test/bothStrict_default.js
+++ b/test/collateral/valid-default/expected-content/test/bothStrict_default.js
@@ -38,5 +38,3 @@ if(strict) {
 } else {
     throw new ReferenceError();
 }
-
-;$DONE();

--- a/test/collateral/valid-default/expected-content/test/bothStrict_strict_mode.js
+++ b/test/collateral/valid-default/expected-content/test/bothStrict_strict_mode.js
@@ -39,5 +39,3 @@ if(strict) {
 } else {
     throw new ReferenceError();
 }
-
-;$DONE();

--- a/test/collateral/valid-default/expected-content/test/error_default.js
+++ b/test/collateral/valid-default/expected-content/test/error_default.js
@@ -32,5 +32,3 @@ $ERROR = function $ERROR(message) {
 
 
 $ERROR('failure message');
-
-;$DONE();

--- a/test/collateral/valid-default/expected-content/test/error_strict_mode.js
+++ b/test/collateral/valid-default/expected-content/test/error_strict_mode.js
@@ -33,5 +33,3 @@ $ERROR = function $ERROR(message) {
 
 
 $ERROR('failure message');
-
-;$DONE();

--- a/test/collateral/valid-default/expected-content/test/module_default.js
+++ b/test/collateral/valid-default/expected-content/test/module_default.js
@@ -32,5 +32,3 @@ $ERROR = function $ERROR(message) {
 
 
 import fixture from './module_FIXTURE.js';
-
-;$DONE();

--- a/test/collateral/valid-default/expected-content/test/module_strict_mode.js
+++ b/test/collateral/valid-default/expected-content/test/module_strict_mode.js
@@ -33,5 +33,3 @@ $ERROR = function $ERROR(message) {
 
 
 import fixture from './module_FIXTURE.js';
-
-;$DONE();

--- a/test/collateral/valid-default/expected-content/test/negative-empty_default.js
+++ b/test/collateral/valid-default/expected-content/test/negative-empty_default.js
@@ -30,5 +30,3 @@ $ERROR = function $ERROR(message) {
 };
 
 
-
-;$DONE();

--- a/test/collateral/valid-default/expected-content/test/negative-empty_strict_mode.js
+++ b/test/collateral/valid-default/expected-content/test/negative-empty_strict_mode.js
@@ -31,5 +31,3 @@ $ERROR = function $ERROR(message) {
 };
 
 
-
-;$DONE();

--- a/test/collateral/valid-default/expected-content/test/noStrict_default.js
+++ b/test/collateral/valid-default/expected-content/test/noStrict_default.js
@@ -31,5 +31,3 @@ $ERROR = function $ERROR(message) {
 
 
 x = 5;
-
-;$DONE();

--- a/test/collateral/valid-default/expected-content/test/strict_strict_mode.js
+++ b/test/collateral/valid-default/expected-content/test/strict_strict_mode.js
@@ -33,5 +33,3 @@ $ERROR = function $ERROR(message) {
 
 x = 5;
 $ERROR('Not in strict mode');
-
-;$DONE();

--- a/test/collateral/valid-extra-files/expected-content/test/bothStrict_default.js
+++ b/test/collateral/valid-extra-files/expected-content/test/bothStrict_default.js
@@ -38,5 +38,3 @@ if(strict) {
 } else {
     throw new ReferenceError();
 }
-
-;$DONE();

--- a/test/collateral/valid-extra-files/expected-content/test/bothStrict_strict_mode.js
+++ b/test/collateral/valid-extra-files/expected-content/test/bothStrict_strict_mode.js
@@ -39,5 +39,3 @@ if(strict) {
 } else {
     throw new ReferenceError();
 }
-
-;$DONE();

--- a/test/collateral/valid-version-ignored/expected-content/test/strict_strict_mode.js
+++ b/test/collateral/valid-version-ignored/expected-content/test/strict_strict_mode.js
@@ -33,5 +33,3 @@ $ERROR = function $ERROR(message) {
 
 x = 5;
 $ERROR('Not in strict mode');
-
-;$DONE();

--- a/test/collateral/valid-version-supported/expected-content/test/strict_strict_mode.js
+++ b/test/collateral/valid-version-supported/expected-content/test/strict_strict_mode.js
@@ -33,5 +33,3 @@ $ERROR = function $ERROR(message) {
 
 x = 5;
 $ERROR('Not in strict mode');
-
-;$DONE();

--- a/test/collateral/valid-with-includes/expected-content/test/bothStrict_default.js
+++ b/test/collateral/valid-with-includes/expected-content/test/bothStrict_default.js
@@ -39,5 +39,3 @@ if(strict) {
 } else {
     throw new ReferenceError();
 }
-
-;$DONE();

--- a/test/collateral/valid-with-includes/expected-content/test/bothStrict_strict_mode.js
+++ b/test/collateral/valid-with-includes/expected-content/test/bothStrict_strict_mode.js
@@ -40,5 +40,3 @@ if(strict) {
 } else {
     throw new ReferenceError();
 }
-
-;$DONE();

--- a/test/collateral/valid-with-paths/expected-content/test/bothStrict_default.js
+++ b/test/collateral/valid-with-paths/expected-content/test/bothStrict_default.js
@@ -38,5 +38,3 @@ if(strict) {
 } else {
     throw new ReferenceError();
 }
-
-;$DONE();

--- a/test/collateral/valid-with-paths/expected-content/test/bothStrict_strict_mode.js
+++ b/test/collateral/valid-with-paths/expected-content/test/bothStrict_strict_mode.js
@@ -39,5 +39,3 @@ if(strict) {
 } else {
     throw new ReferenceError();
 }
-
-;$DONE();

--- a/test/collateral/valid-with-paths/expected-content/test/strict/no/noStrict_default.js
+++ b/test/collateral/valid-with-paths/expected-content/test/strict/no/noStrict_default.js
@@ -31,5 +31,3 @@ $ERROR = function $ERROR(message) {
 
 
 x = 5;
-
-;$DONE();


### PR DESCRIPTION
This project inherited code from the `test262-compiler` project which
was tightly coupled to the `test262-harness` project. This coupling is
apparent in a modification made to synchronous tests: the insertion of
an invocation of the `$DONE` function. Test262's interpreting guidelines
make no mention of such a transformation.

Remove the modification in order to comply with that document.
(Consumers of `test262-stream` who rely on this functionality may
re-implement it by transforming the test stream.)