### PR TITLE
Bump test262-parser dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   },
   "dependencies": {
     "klaw": "^2.1.0",
-    "test262-parser": "^2.0.7"
+    "test262-parser": "^2.0.10"
   }
 }


### PR DESCRIPTION
This version supports the new hashbang tests. See #18 and #19 for a bit of context. This is a minimal change providing the required feature.