### PR TITLE
Fix indentationIndex to accomodate the presense of copyright headers

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -39,7 +39,7 @@ module.exports = function compile(descriptor, options) {
   }
 
   test.contents = preludeContents + test.contents;
-  test.insertionIndex = preludeContents.length + 1;
+  test.insertionIndex = preludeContents.length;
 
   return test;
 };

--- a/test/collateral/valid-default/expected-metadata/test/asyncNegative_default.json
+++ b/test/collateral/valid-default/expected-metadata/test/asyncNegative_default.json
@@ -18,5 +18,5 @@
   },
   "copyright": "",
   "scenario": "default",
-  "insertionIndex": 565
+  "insertionIndex": 564
 }

--- a/test/collateral/valid-default/expected-metadata/test/asyncNegative_strict_mode.json
+++ b/test/collateral/valid-default/expected-metadata/test/asyncNegative_strict_mode.json
@@ -18,5 +18,5 @@
   },
   "copyright": "",
   "scenario": "strict mode",
-  "insertionIndex": 579
+  "insertionIndex": 578
 }

--- a/test/collateral/valid-default/expected-metadata/test/async_default.json
+++ b/test/collateral/valid-default/expected-metadata/test/async_default.json
@@ -14,5 +14,5 @@
   },
   "copyright": "",
   "scenario": "default",
-  "insertionIndex": 565
+  "insertionIndex": 564
 }

--- a/test/collateral/valid-default/expected-metadata/test/async_strict_mode.json
+++ b/test/collateral/valid-default/expected-metadata/test/async_strict_mode.json
@@ -14,5 +14,5 @@
   },
   "copyright": "",
   "scenario": "strict mode",
-  "insertionIndex": 579
+  "insertionIndex": 578
 }

--- a/test/collateral/valid-default/expected-metadata/test/bothStrict_default.json
+++ b/test/collateral/valid-default/expected-metadata/test/bothStrict_default.json
@@ -20,5 +20,5 @@
   },
   "copyright": "",
   "scenario": "default",
-  "insertionIndex": 440
+  "insertionIndex": 439
 }

--- a/test/collateral/valid-default/expected-metadata/test/bothStrict_strict_mode.json
+++ b/test/collateral/valid-default/expected-metadata/test/bothStrict_strict_mode.json
@@ -20,5 +20,5 @@
   },
   "copyright": "",
   "scenario": "strict mode",
-  "insertionIndex": 454
+  "insertionIndex": 453
 }

--- a/test/collateral/valid-default/expected-metadata/test/error_strict_mode.json
+++ b/test/collateral/valid-default/expected-metadata/test/error_strict_mode.json
@@ -15,5 +15,5 @@
   },
   "copyright": "",
   "scenario": "strict mode",
-  "insertionIndex": 454
+  "insertionIndex": 453
 }

--- a/test/collateral/valid-default/expected-metadata/test/module_default.json
+++ b/test/collateral/valid-default/expected-metadata/test/module_default.json
@@ -13,5 +13,5 @@
   },
   "copyright": "",
   "scenario": "default",
-  "insertionIndex": 440
+  "insertionIndex": 439
 }

--- a/test/collateral/valid-default/expected-metadata/test/negative-empty_default.json
+++ b/test/collateral/valid-default/expected-metadata/test/negative-empty_default.json
@@ -15,5 +15,5 @@
   },
   "copyright": "",
   "scenario": "default",
-  "insertionIndex": 440
+  "insertionIndex": 439
 }

--- a/test/collateral/valid-default/expected-metadata/test/negative-empty_strict_mode.json
+++ b/test/collateral/valid-default/expected-metadata/test/negative-empty_strict_mode.json
@@ -15,5 +15,5 @@
   },
   "copyright": "",
   "scenario": "strict mode",
-  "insertionIndex": 454
+  "insertionIndex": 453
 }

--- a/test/collateral/valid-default/expected-metadata/test/noStrict_default.json
+++ b/test/collateral/valid-default/expected-metadata/test/noStrict_default.json
@@ -13,5 +13,5 @@
   },
   "copyright": "",
   "scenario": "default",
-  "insertionIndex": 440
+  "insertionIndex": 439
 }

--- a/test/collateral/valid-default/expected-metadata/test/strict_strict_mode.json
+++ b/test/collateral/valid-default/expected-metadata/test/strict_strict_mode.json
@@ -17,5 +17,5 @@
   },
   "copyright": "",
   "scenario": "strict mode",
-  "insertionIndex": 454
+  "insertionIndex": 453
 }

--- a/test/collateral/valid-extra-files/expected-metadata/test/bothStrict_default.json
+++ b/test/collateral/valid-extra-files/expected-metadata/test/bothStrict_default.json
@@ -20,5 +20,5 @@
   },
   "copyright": "",
   "scenario": "default",
-  "insertionIndex": 440
+  "insertionIndex": 439
 }

--- a/test/collateral/valid-extra-files/expected-metadata/test/bothStrict_strict_mode.json
+++ b/test/collateral/valid-extra-files/expected-metadata/test/bothStrict_strict_mode.json
@@ -20,5 +20,5 @@
   },
   "copyright": "",
   "scenario": "strict mode",
-  "insertionIndex": 454
+  "insertionIndex": 453
 }

--- a/test/collateral/valid-insertionindex-with-copyright/expected-content/test/raw_default.js
+++ b/test/collateral/valid-insertionindex-with-copyright/expected-content/test/raw_default.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2048 $ContributorName. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+
+var strict;
+try { x = 1; strict = false;} catch(e) { strict = true }
+
+if(strict) {
+    y = 1;
+} else {
+    throw new ReferenceError();
+}

--- a/test/collateral/valid-insertionindex-with-copyright/expected-content/test/runtime_default.js
+++ b/test/collateral/valid-insertionindex-with-copyright/expected-content/test/runtime_default.js
@@ -1,0 +1,36 @@
+// This is assert.js
+
+'It has some contents';
+
+/* that
+ *
+ * should
+
+ * not
+ */
+
+`be ${ "modified" }`;
+
+var including, trailing;
+whitespace: ;                    
+
+void "end of assert.js";
+
+function Test262Error(message) {
+  this.message = message || "";
+}
+
+Test262Error.prototype.toString = function () {
+  return "Test262Error: " + this.message;
+};
+
+var $ERROR;
+$ERROR = function $ERROR(message) {
+  throw new Test262Error(message);
+};
+
+// Copyright (C) 2048 $ContributorName. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+
+assert(true);

--- a/test/collateral/valid-insertionindex-with-copyright/expected-content/test/runtime_strict_mode.js
+++ b/test/collateral/valid-insertionindex-with-copyright/expected-content/test/runtime_strict_mode.js
@@ -1,0 +1,37 @@
+"use strict";
+// This is assert.js
+
+'It has some contents';
+
+/* that
+ *
+ * should
+
+ * not
+ */
+
+`be ${ "modified" }`;
+
+var including, trailing;
+whitespace: ;                    
+
+void "end of assert.js";
+
+function Test262Error(message) {
+  this.message = message || "";
+}
+
+Test262Error.prototype.toString = function () {
+  return "Test262Error: " + this.message;
+};
+
+var $ERROR;
+$ERROR = function $ERROR(message) {
+  throw new Test262Error(message);
+};
+
+// Copyright (C) 2048 $ContributorName. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+
+assert(true);

--- a/test/collateral/valid-insertionindex-with-copyright/expected-metadata/test/raw_default.json
+++ b/test/collateral/valid-insertionindex-with-copyright/expected-metadata/test/raw_default.json
@@ -1,0 +1,14 @@
+{
+  "file": "test/raw.js",
+  "contents": "(The value of this property is over-sized, so it is validated independently.)",
+  "attrs": {
+    "description": "License and correct insertionIndex",
+    "flags": {
+      "raw": true
+    },
+    "includes": []
+  },
+  "copyright": "// Copyright (C) 2048 $ContributorName. All rights reserved.",
+  "scenario": "default",
+  "insertionIndex": -1
+}

--- a/test/collateral/valid-insertionindex-with-copyright/expected-metadata/test/runtime_default.json
+++ b/test/collateral/valid-insertionindex-with-copyright/expected-metadata/test/runtime_default.json
@@ -1,19 +1,15 @@
 {
-  "file": "test/error.js",
+  "file": "test/runtime.js",
   "contents": "(The value of this property is over-sized, so it is validated independently.)",
   "attrs": {
-    "description": "Fails by calling $ERROR",
-    "negative": {
-      "phase": "runtime",
-      "type": "Test262Error"
-    },
+    "description": "License and correct insertionIndex",
     "flags": {},
     "includes": [
       "assert.js",
       "sta.js"
     ]
   },
-  "copyright": "",
+  "copyright": "// Copyright (C) 2048 $ContributorName. All rights reserved.",
   "scenario": "default",
   "insertionIndex": 439
 }

--- a/test/collateral/valid-insertionindex-with-copyright/expected-metadata/test/runtime_strict_mode.json
+++ b/test/collateral/valid-insertionindex-with-copyright/expected-metadata/test/runtime_strict_mode.json
@@ -1,17 +1,15 @@
 {
-  "file": "test/module.js",
+  "file": "test/runtime.js",
   "contents": "(The value of this property is over-sized, so it is validated independently.)",
   "attrs": {
-    "description": "A test for module code (Strict Mode)",
-    "flags": {
-      "module": true
-    },
+    "description": "License and correct insertionIndex (Strict Mode)",
+    "flags": {},
     "includes": [
       "assert.js",
       "sta.js"
     ]
   },
-  "copyright": "",
+  "copyright": "// Copyright (C) 2048 $ContributorName. All rights reserved.",
   "scenario": "strict mode",
   "insertionIndex": 453
 }

--- a/test/collateral/valid-insertionindex-with-copyright/fake-test262/harness/assert.js
+++ b/test/collateral/valid-insertionindex-with-copyright/fake-test262/harness/assert.js
@@ -1,0 +1,17 @@
+// This is assert.js
+
+'It has some contents';
+
+/* that
+ *
+ * should
+
+ * not
+ */
+
+`be ${ "modified" }`;
+
+var including, trailing;
+whitespace: ;                    
+
+void "end of assert.js";

--- a/test/collateral/valid-insertionindex-with-copyright/fake-test262/harness/sta.js
+++ b/test/collateral/valid-insertionindex-with-copyright/fake-test262/harness/sta.js
@@ -1,0 +1,12 @@
+function Test262Error(message) {
+  this.message = message || "";
+}
+
+Test262Error.prototype.toString = function () {
+  return "Test262Error: " + this.message;
+};
+
+var $ERROR;
+$ERROR = function $ERROR(message) {
+  throw new Test262Error(message);
+};

--- a/test/collateral/valid-insertionindex-with-copyright/fake-test262/test/raw.js
+++ b/test/collateral/valid-insertionindex-with-copyright/fake-test262/test/raw.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2048 $ContributorName. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: License and correct insertionIndex
+flags: [raw]
+---*/
+var strict;
+try { x = 1; strict = false;} catch(e) { strict = true }
+
+if(strict) {
+    y = 1;
+} else {
+    throw new ReferenceError();
+}

--- a/test/collateral/valid-insertionindex-with-copyright/fake-test262/test/runtime.js
+++ b/test/collateral/valid-insertionindex-with-copyright/fake-test262/test/runtime.js
@@ -1,0 +1,7 @@
+// Copyright (C) 2048 $ContributorName. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: License and correct insertionIndex
+---*/
+assert(true);

--- a/test/collateral/valid-version-ignored/expected-metadata/test/strict_strict_mode.json
+++ b/test/collateral/valid-version-ignored/expected-metadata/test/strict_strict_mode.json
@@ -17,5 +17,5 @@
   },
   "copyright": "",
   "scenario": "strict mode",
-  "insertionIndex": 454
+  "insertionIndex": 453
 }

--- a/test/collateral/valid-version-supported/expected-metadata/test/strict_strict_mode.json
+++ b/test/collateral/valid-version-supported/expected-metadata/test/strict_strict_mode.json
@@ -17,5 +17,5 @@
   },
   "copyright": "",
   "scenario": "strict mode",
-  "insertionIndex": 454
+  "insertionIndex": 453
 }

--- a/test/collateral/valid-with-hashbang/expected-metadata/test/missing-raw-flag_default.json
+++ b/test/collateral/valid-with-hashbang/expected-metadata/test/missing-raw-flag_default.json
@@ -18,5 +18,5 @@
   },
   "copyright": "",
   "scenario": "default",
-  "insertionIndex": 440
+  "insertionIndex": 439
 }

--- a/test/collateral/valid-with-hashbang/expected-metadata/test/missing-raw-flag_strict_mode.json
+++ b/test/collateral/valid-with-hashbang/expected-metadata/test/missing-raw-flag_strict_mode.json
@@ -18,5 +18,5 @@
   },
   "copyright": "",
   "scenario": "strict mode",
-  "insertionIndex": 454
+  "insertionIndex": 453
 }

--- a/test/collateral/valid-with-includes/expected-metadata/test/async_default.json
+++ b/test/collateral/valid-with-includes/expected-metadata/test/async_default.json
@@ -14,5 +14,5 @@
   },
   "copyright": "",
   "scenario": "default",
-  "insertionIndex": 805
+  "insertionIndex": 804
 }

--- a/test/collateral/valid-with-includes/expected-metadata/test/async_strict_mode.json
+++ b/test/collateral/valid-with-includes/expected-metadata/test/async_strict_mode.json
@@ -14,5 +14,5 @@
   },
   "copyright": "",
   "scenario": "strict mode",
-  "insertionIndex": 819
+  "insertionIndex": 818
 }

--- a/test/collateral/valid-with-includes/expected-metadata/test/bothStrict_default.json
+++ b/test/collateral/valid-with-includes/expected-metadata/test/bothStrict_default.json
@@ -20,5 +20,5 @@
   },
   "copyright": "",
   "scenario": "default",
-  "insertionIndex": 550
+  "insertionIndex": 549
 }

--- a/test/collateral/valid-with-includes/expected-metadata/test/bothStrict_strict_mode.json
+++ b/test/collateral/valid-with-includes/expected-metadata/test/bothStrict_strict_mode.json
@@ -20,5 +20,5 @@
   },
   "copyright": "",
   "scenario": "strict mode",
-  "insertionIndex": 564
+  "insertionIndex": 563
 }

--- a/test/collateral/valid-with-paths/expected-metadata/test/async/asyncNegative_default.json
+++ b/test/collateral/valid-with-paths/expected-metadata/test/async/asyncNegative_default.json
@@ -18,5 +18,5 @@
   },
   "copyright": "",
   "scenario": "default",
-  "insertionIndex": 565
+  "insertionIndex": 564
 }

--- a/test/collateral/valid-with-paths/expected-metadata/test/async/asyncNegative_strict_mode.json
+++ b/test/collateral/valid-with-paths/expected-metadata/test/async/asyncNegative_strict_mode.json
@@ -18,5 +18,5 @@
   },
   "copyright": "",
   "scenario": "strict mode",
-  "insertionIndex": 579
+  "insertionIndex": 578
 }

--- a/test/collateral/valid-with-paths/expected-metadata/test/async/async_default.json
+++ b/test/collateral/valid-with-paths/expected-metadata/test/async/async_default.json
@@ -14,5 +14,5 @@
   },
   "copyright": "",
   "scenario": "default",
-  "insertionIndex": 565
+  "insertionIndex": 564
 }

--- a/test/collateral/valid-with-paths/expected-metadata/test/async/async_strict_mode.json
+++ b/test/collateral/valid-with-paths/expected-metadata/test/async/async_strict_mode.json
@@ -14,5 +14,5 @@
   },
   "copyright": "",
   "scenario": "strict mode",
-  "insertionIndex": 579
+  "insertionIndex": 578
 }

--- a/test/collateral/valid-with-paths/expected-metadata/test/bothStrict_default.json
+++ b/test/collateral/valid-with-paths/expected-metadata/test/bothStrict_default.json
@@ -20,5 +20,5 @@
   },
   "copyright": "",
   "scenario": "default",
-  "insertionIndex": 440
+  "insertionIndex": 439
 }

--- a/test/collateral/valid-with-paths/expected-metadata/test/bothStrict_strict_mode.json
+++ b/test/collateral/valid-with-paths/expected-metadata/test/bothStrict_strict_mode.json
@@ -20,5 +20,5 @@
   },
   "copyright": "",
   "scenario": "strict mode",
-  "insertionIndex": 454
+  "insertionIndex": 453
 }

--- a/test/collateral/valid-with-paths/expected-metadata/test/strict/no/noStrict_default.json
+++ b/test/collateral/valid-with-paths/expected-metadata/test/strict/no/noStrict_default.json
@@ -13,5 +13,5 @@
   },
   "copyright": "",
   "scenario": "default",
-  "insertionIndex": 440
+  "insertionIndex": 439
 }

--- a/test/test.js
+++ b/test/test.js
@@ -299,3 +299,21 @@ tape('valid source directory (with hashbang tests)', t => {
     t.end();
   });
 });
+
+tape('copyright and insertionIndex integrity', t => {
+  const fixtureDir = path.join(__dirname, 'collateral', 'valid-insertionindex-with-copyright');
+  const stream = new TestStream(path.join(fixtureDir, 'fake-test262'));
+  const ids = [];
+
+  stream.on('data', makeDataHandler(t, ids, fixtureDir));
+
+  stream.on('error', (error) => {
+    t.ok(error);
+    t.end(error);
+  });
+
+  stream.on('end', () => {
+    t.equal(ids.length, 3, 'Reports every available test');
+    t.end();
+  });
+});


### PR DESCRIPTION
Before hashbangs, test262-stream just stripped out everything up to and including the closing "---*/". Now there is no unambiguous way to do that safely now that hashbangs have been introduced and must be preserved. That means we can no longer pad the insertionIndex by one extra space after the includes have been prepended.